### PR TITLE
#144 create error handling page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # misc
 .DS_Store
+.idea
 .env
 .env.local
 .env.development.local

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import AddRoom from "components/AddRoom/AddRoom";
 import Myroom from "components/Myroom/Myroom";
 import Mypage from "components/Mypage/Mypage";
 import WrapChat from "components/Chatting/WrapChat";
+import Error from "components/Error/Error";
 
 import "App.css";
 import "Font.css";
@@ -27,6 +28,8 @@ const App = () => {
           <Route exact path="/myroom/:roomId" component={Myroom} />
           <Route exact path="/mypage" component={Mypage} />
           <Route exact path="/chatting/:roomId" component={WrapChat} />
+          <Route exact path="/error/:error" component={Error} />
+          <Route path="*" component={Error} />
         </Switch>
       </Skeleton>
     </Router>

--- a/src/components/Error/Error.jsx
+++ b/src/components/Error/Error.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Title from "../common/Title";
+import { useParams } from "react-router-dom";
+
+const Error = () => {
+  const { error } = useParams();
+  const errorState = error ? error : "404 Not Found!";
+  return (
+    <div>
+      <Title icon="error" header={true}>
+        오류가 발생하였습니다
+      </Title>
+      <div>{errorState}</div>
+    </div>
+  );
+};
+
+export default Error;

--- a/src/components/Error/Error.jsx
+++ b/src/components/Error/Error.jsx
@@ -1,17 +1,72 @@
 import React from "react";
-import Title from "../common/Title";
-import { useParams } from "react-router-dom";
+import Title from "components/common/Title";
+import Spacer from "components/common/utils/Spacer";
+import SubmitButton from "components/common/roomOptions/SubmitButton";
+import { useParams, Link, useHistory } from "react-router-dom";
+import RLayout from "components/common/RLayout";
 
 const Error = () => {
   const { error } = useParams();
-  const errorState = error ? error : "404 Not Found!";
+  const history = useHistory();
+
+  // FIXME Global State 에서 오류 가져오기
+  const errorPrimaryState = error ? error : "404";
+  const errorSecondaryState = "예상치 못한 오류가 발생하였습니다";
+
+  const onClickGoBack = () => {
+    history.goBack();
+  };
+
   return (
-    <div>
+    <RLayout.R1>
       <Title icon="error" header={true}>
         오류가 발생하였습니다
       </Title>
-      <div>{errorState}</div>
-    </div>
+      <div id="error-body">
+        <Spacer height={80} />
+        <h1
+          style={{
+            fontSize: "60px",
+            fontWeight: "bold",
+            textAlign: "center",
+            color: "#6E3678",
+          }}
+        >
+          {errorPrimaryState}
+        </h1>
+        <Spacer height={15} />
+        <p
+          style={{
+            fontSize: "16px",
+            textAlign: "center",
+            color: "#888888",
+          }}
+        >
+          {errorSecondaryState}
+        </p>
+      </div>
+      <Spacer height={110} />
+      <SubmitButton
+        background="#EFEFEFAA"
+        backgroundHover="#EFEFEF"
+        textColor="#888888"
+        disable={false}
+        marginAuto={false}
+        onClick={onClickGoBack}
+      >
+        이전 페이지로 돌아가기
+      </SubmitButton>
+      <Spacer height={12} />
+      <Link to="/">
+        <SubmitButton
+          marginAuto={false}
+          backgroundHover="#572A5E"
+          disable={false}
+        >
+          Taxi 홈으로 돌아가기
+        </SubmitButton>
+      </Link>
+    </RLayout.R1>
   );
 };
 

--- a/src/components/common/Title.jsx
+++ b/src/components/common/Title.jsx
@@ -2,14 +2,15 @@ import React from "react";
 import PropTypes from "prop-types";
 import RLayout from "components/common/RLayout";
 
-import SearchRoundedIcon from "@material-ui/icons/SearchRounded";
-import ListAltRoundedIcon from "@material-ui/icons/ListAltRounded";
-import LibraryBooksRoundedIcon from "@material-ui/icons/LibraryBooksRounded";
-import HistoryRoundedIcon from "@material-ui/icons/HistoryRounded";
-import QuestionAnswerRoundedIcon from "@material-ui/icons/QuestionAnswerRounded";
-import AccountCircleRoundedIcon from "@material-ui/icons/AccountCircleRounded";
-import LocalTaxiRoundedIcon from "@material-ui/icons/LocalTaxiRounded";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import ListAltRoundedIcon from "@mui/icons-material/ListAltRounded";
+import LibraryBooksRoundedIcon from "@mui/icons-material/LibraryBooksRounded";
+import HistoryRoundedIcon from "@mui/icons-material/HistoryRounded";
+import QuestionAnswerRoundedIcon from "@mui/icons-material/QuestionAnswerRounded";
+import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
+import LocalTaxiRoundedIcon from "@mui/icons-material/LocalTaxiRounded";
 import LibraryAddRoundedIcon from "@mui/icons-material/LibraryAddRounded";
+import ErrorOutlineRounded from "@mui/icons-material/ErrorOutlineRounded";
 
 const iconStyle = {
   width: "24px",
@@ -35,6 +36,8 @@ const getIcon = (icon) => {
       return <QuestionAnswerRoundedIcon style={iconStyle} />;
     case "mypage":
       return <AccountCircleRoundedIcon style={iconStyle} />;
+    case "error":
+      return <ErrorOutlineRounded style={iconStyle} />;
     default:
       return <></>;
   }

--- a/src/components/common/roomOptions/SubmitButton.jsx
+++ b/src/components/common/roomOptions/SubmitButton.jsx
@@ -11,7 +11,7 @@ const Button = (props) => {
     lineHeight: "19px",
     textAlign: "center",
     fontSize: "16px",
-    color: props.disable ? "#888888" : "white",
+    color: props.disable ? "#888888" : props.textColor,
     fontWeight: "bold",
     borderRadius: "12px",
     boxShadow:
@@ -50,6 +50,7 @@ Button.propTypes = {
   // FIXME specify type
   backgroundHover: PropTypes.any,
   background: PropTypes.any,
+  textColor: PropTypes.any,
   onClick: PropTypes.func,
   children: PropTypes.any,
   marginAuto: PropTypes.any,
@@ -60,6 +61,7 @@ Button.defaultProps = {
   background: "#6E3678",
   backgroundHover: "#572A5E",
   marginAuto: true,
+  textColor: "white",
   onClick: () => {},
   disable: true,
 };

--- a/src/components/common/roomOptions/SubmitButton.jsx
+++ b/src/components/common/roomOptions/SubmitButton.jsx
@@ -50,7 +50,7 @@ Button.propTypes = {
   // FIXME specify type
   backgroundHover: PropTypes.any,
   background: PropTypes.any,
-  textColor: PropTypes.any,
+  textColor: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.any,
   marginAuto: PropTypes.any,

--- a/src/components/common/utils/Spacer.jsx
+++ b/src/components/common/utils/Spacer.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const Spacer = (props) => {
+  return <div style={{ height: `${props.height}px` }} />;
+};
+Spacer.propTypes = {
+  height: PropTypes.number,
+};
+
+export default Spacer;


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

Error Page의 임시 구현

It closes #144

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
<img width="1840" alt="Screen Shot 2022-08-11 at 5 00 03" src="https://user-images.githubusercontent.com/26193650/184008892-bd9891ce-9d67-4469-8577-8eae79f51fa1.png">


# Further Work <!-- PR 이후 개설할 이슈 목록 -->
- Error Set을 만들어서 Set 내부에서 선택할 수 있게 제작 (Error Set정의 논의 필요)
- Error Page에 state를 넘겨 주기 위한 global state 적용 필요
- Error Hanler에서 쉽게 Error Page로 필요한 Telemetry 이후 Redirect 할 수 있는 Component 필요
- i18n 도입으로 한글 / 영어 동시 지원 필요

