### PR TITLE
[Bug] Socket.io handshake is not established under reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 REACT_APP_BACK_URL=[back url(e.g. http://localhost:80)]
+REACT_APP_IO_URL=[Socket.io server url(e.g. http://localhost:80)] # 주어지지 않은 경우 REACT_APP_BACK_URL로 설정됩니다.
 REACT_APP_S3_URL=[aws s3 baseline url]

--- a/src/components/Chatting/Chatting.jsx
+++ b/src/components/Chatting/Chatting.jsx
@@ -7,7 +7,7 @@ import MessagesBody from "./MessagesBody/MessagesBody";
 import MessageForm from "./MessageForm/MessageForm";
 import regExpTest from "tools/regExpTest";
 
-import { backServer } from "serverconf";
+import { ioServer } from "serverconf";
 import convertImg from "tools/convertImg";
 import axios from "tools/axios";
 import axiosOri from "axios";
@@ -99,7 +99,7 @@ const Chatting = (props) => {
   useEffect(() => {
     if (headerInfo) {
       socket.current?.disconnect();
-      socket.current = io(backServer, {
+      socket.current = io(ioServer, {
         withCredentials: true,
       });
 

--- a/src/serverconf.js
+++ b/src/serverconf.js
@@ -2,5 +2,6 @@ import dotenv from "dotenv";
 
 dotenv.config();
 const backServer = process.env.REACT_APP_BACK_URL;
+const ioServer = process.env.REACT_APP_IO_URL ?? backServer;
 
-export { backServer };
+export { backServer, ioServer };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #178 and fixes https://github.com/sparcs-kaist/taxi-back/issues/111

`/api`로 끝나는 주소로 온 요청을 백엔드로 전달하는 reverse proxy를 설정한 뒤 클라이언트에서 소켓 연결을 시도할 때 기본 네임스페이스(`/`)가 아닌 서버에서 정의되지 않은 네임스페이스(`/api` 등)로 연결을 시도하는 문제가 발생했습니다.
문제를 해결하기 위해 클라이언트에 Socket.io 서버의 주소를 저장하는 `ioServer` 변수를 추가해 무조건 기본 네임스페이스(`/`)로 연결을 시도하도록 수정했습니다.
`ioServer`의 값은 `REACT_APP_IO_URL` 환경변수가 설정되어 있다면 그 값으로, 설정되어 있지 않다면 백엔드 주소(`REACT_APP_BACK_URL` 환경변수의 값)으로 설정했습니다.
따라서 메인 브랜치 머지 이후에도 리버스 프록시 없이 서버를 구동한다면(e.g.) 로컬에서 테스트) 환경변수를 추가할 필요는 없습니다.

#178 브랜치의 변경 사항을 아래 주소에서 테스트해보실 수 있습니다.
https://taxi-test.withsang.com/

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="634" alt="KakaoTalk_Photo_2022-08-14-22-03-30" src="https://user-images.githubusercontent.com/46402016/184538276-4bd96129-9174-4482-a545-3abd7b355135.png">


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
