### PR TITLE
Fix: apply getLocationName to location objects on mobile as well

### DIFF
--- a/src/components/Search/SideResult.jsx
+++ b/src/components/Search/SideResult.jsx
@@ -53,8 +53,8 @@ const SideResult = (props) => {
             return (
               <Room
                 name={room.name}
-                origin={room.from}
-                destination={room.to}
+                origin={getLocationName(room.from)}
+                destination={getLocationName(room.to)}
                 date={room.time}
                 key={index}
                 marginTop="0px"


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #166 again
모바일 환경에서 `Objects are not valid as a React child` 오류가 발생해서 @GrasshopperBears 님께서 수정하신 사항을 모바일용 검색결과 컴포넌트에도 반영했습니다!
늦은 시간에 죄송해요.. 😢 
> Error: Objects are not valid as a React child (found: object with keys {_id, enName, koName}). If you meant to render a collection of children, use an array instead.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->



| 수정 전: 검색 결과가 하나 이상일 때 오류가 발생했습니다. | 수정 후: 오류가 발생하지 않습니다.  |
|---|---|
| <img width="375" alt="스크린샷 2022-08-15 오전 3 32 51" src="https://user-images.githubusercontent.com/46402016/184550294-31be3ed9-3442-4ca1-904c-968c7eb4a5aa.png">  | <img width="387" alt="스크린샷 2022-08-15 오전 3 30 33" src="https://user-images.githubusercontent.com/46402016/184550226-17c81a8d-6474-4837-9fbe-88e112c2a6a1.png">  |






# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
