### PR TITLE
#181 Create common modal component

### DIFF
--- a/src/components/common/modal/Modal.jsx
+++ b/src/components/common/modal/Modal.jsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from "react";
+import { animated, useSpring } from "react-spring";
+import RLayout from "components/common/RLayout";
+import PropTypes from "prop-types";
+
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+
+const ModalBackground = (props) => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "0px",
+        left: "0px",
+        width: "100%",
+        height: "100%",
+      }}
+      onClick={props.onClick}
+    />
+  );
+};
+ModalBackground.propTypes = {
+  onClick: PropTypes.func,
+};
+
+const BtnClose = (props) => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "10px",
+        right: "10px",
+        width: "24px",
+        height: "24px",
+      }}
+      className="BTNC"
+      onClick={props.onClick}
+    >
+      <CloseRoundedIcon style={{ width: "100%", height: "100%" }} />
+    </div>
+  );
+};
+BtnClose.propTypes = {
+  onClick: PropTypes.func,
+};
+
+const Modal = (props) => {
+  const styleCont = useSpring({
+    position: "fixed",
+    top: "0px",
+    left: "0px",
+    width: "100%",
+    height: "100%",
+    zIndex: 150,
+    background: `rgba(0,0,0,0.6)`,
+    opacity: props.display ? 1 : 0,
+    pointerEvents: props.display ? "auto" : "none",
+  });
+  return (
+    <animated.div style={styleCont}>
+      <ModalBackground onClick={props.onClickClose} />
+      <div
+        style={{
+          position: "absolute",
+          top: props.top,
+          bottom: props.bottom,
+          left: "0px",
+          right: "0px",
+        }}
+      >
+        <ModalBackground onClick={props.onClickClose} />
+        <RLayout.R1 height="100%">
+          <ModalBackground onClick={props.onClickClose} />
+          <div
+            style={{
+              position: "relative",
+              maxWidth: props.maxWidth,
+              margin: "auto",
+              maxHeight: "100%",
+              overflow: "hidden",
+              background: "#FFFFFF",
+              boxShadow: "0px 1px 7.5px 2px rgba(0, 0, 0, 0.05)",
+              borderRadius: "15px",
+            }}
+          >
+            <div
+              style={{
+                position: "relative",
+                padding: props.padding,
+              }}
+            >
+              {props.children}
+            </div>
+            {props.btnCloseDisplay ? (
+              <BtnClose onClick={props.onClickClose} />
+            ) : null}
+          </div>
+        </RLayout.R1>
+      </div>
+    </animated.div>
+  );
+};
+
+Modal.propTypes = {
+  display: PropTypes.bool,
+  onClickClose: PropTypes.func,
+  top: PropTypes.string,
+  bottom: PropTypes.string,
+  maxWidth: PropTypes.string,
+  padding: PropTypes.padding,
+  children: PropTypes.any,
+  btnCloseDisplay: PropTypes.bool,
+};
+Modal.defaultProps = {
+  onClickClose: () => {},
+  top: "120px",
+  bottom: "40px",
+  maxWidth: "100%",
+  padding: "0px",
+  btnCloseDisplay: false,
+};
+
+export default Modal;


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #181 
공통으로 사용할 수 있는 modal 컴포넌트를 만듭니다.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? y
- Needs to execute in order to review? n

#Images
 - maxWidth="325px"의 prop을 사용한 경우
<img width="1087" alt="스크린샷 2022-08-16 오후 5 06 56" src="https://user-images.githubusercontent.com/69258815/184829901-0ba0ffc0-4524-44f8-9dfa-3b529073a43e.png">
 - default 값은 maxWidth="100%"의 prop을 사용한 경우
<img width="920" alt="스크린샷 2022-08-16 오후 5 09 02" src="https://user-images.githubusercontent.com/69258815/184830298-bc9ffecd-e367-4514-976e-3993e0c202f0.png">


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- common modal 컴포넌트에서 사용할 수 있는 버튼 컴포넌트 만들기
