### PR TITLE
[Bug] 프로덕션 환경에서 REACT_APP_S3_URL 환경변수 주입 안됨

### DIFF
--- a/src/serverconf.js
+++ b/src/serverconf.js
@@ -2,12 +2,20 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-const env = { ...process.env, ...window['env'] }
+const env = { ...process.env, ...window["env"] };
 
 const nodeEnv = env.NODE_ENV;
 const backServer = env.REACT_APP_BACK_URL;
 const ioServer = env.REACT_APP_IO_URL ?? backServer;
+const s3BaseUrl = env.REACT_APP_S3_URL;
 const channelTalkPluginKey = env.REACT_APP_CHANNELTALK_PLUGIN_KEY;
 const gaTrackingId = env.REACT_APP_GA_TRACKING_ID;
 
-export { nodeEnv, backServer, ioServer, channelTalkPluginKey, gaTrackingId };
+export {
+  nodeEnv,
+  backServer,
+  ioServer,
+  s3BaseUrl,
+  channelTalkPluginKey,
+  gaTrackingId,
+};

--- a/src/tools/trans.js
+++ b/src/tools/trans.js
@@ -1,5 +1,7 @@
+import { s3BaseUrl } from "serverconf";
+
 const getS3Url = (x) => {
-  return `${process.env.REACT_APP_S3_URL}${x}`;
+  return `${s3BaseUrl}{x}`;
 };
 
 const getLocationName = (location, langPreference) => {

--- a/src/tools/trans.js
+++ b/src/tools/trans.js
@@ -1,8 +1,6 @@
 import { s3BaseUrl } from "serverconf";
 
-const getS3Url = (x) => {
-  return `${s3BaseUrl}{x}`;
-};
+const getS3Url = (x) => `${s3BaseUrl}${x}`;
 
 const getLocationName = (location, langPreference) => {
   if (!location) return "";


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #447
react-inject-env가 S3 버킷 주소 환경변수를 추가할 수 있게 process.env를 `serverconf.js`에서 정의한 env로 대체합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
<img width="432" alt="스크린샷 2023-02-08 오후 3 25 25" src="https://user-images.githubusercontent.com/46402016/217451303-6932e294-5b1f-4cba-a3b0-0ee5a7bd1cd6.png">
로컬에서 환경변수 로딩 잘 되는 모습입니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->
- 없음.
