### PR TITLE
#483 FCM background 메시지 핸들러 변경

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -24,10 +24,10 @@ const messaging = firebase.messaging();
 // 백그라운드 메시지가 도착했을 때 알림을 표시하는 이벤트 리스너를 추가합니다.
 messaging.onBackgroundMessage((payload) => {
   // 알림의 제목을 설정하는 notificationTitle을 생성합니다.
-  const notificationTitle = payload?.data?.title || "Title does not exist";
+  const notificationTitle = payload?.data?.title || "SPARCS Taxi";
 
   // 알림의 제목을 제외한 내용을 구성하는 notificationOption을 생성합니다.
-  const body = payload?.data?.body || "Body does not exist";
+  const body = payload?.data?.body || "There's a new message!";
   const icon = payload?.data?.icon || "/icons-512.png";
   const url = payload?.data?.url || "/";
   const notificationOptions = {

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -19,4 +19,32 @@ const defaultConfig = {
 firebase.initializeApp(self.firebaseConfig || defaultConfig);
 
 // 백그라운드 메시지를 처리할 수 있게 FCM 인스턴스를 생성합니다.
-firebase.messaging();
+const messaging = firebase.messaging();
+
+// 백그라운드 메시지가 도착했을 때 알림을 표시하는 이벤트 리스너를 추가합니다.
+messaging.onBackgroundMessage((payload) => {
+  // 알림의 제목을 설정하는 notificationTitle을 생성합니다.
+  const notificationTitle = payload?.data?.title || "Title does not exist";
+
+  // 알림의 제목을 제외한 내용을 구성하는 notificationOption을 생성합니다.
+  const body = payload?.data?.body || "Body does not exist";
+  const icon = payload?.data?.icon || "/icons-512.png";
+  const url = payload?.data?.url || "/";
+  const notificationOptions = {
+    body,
+    icon,
+    data: {
+      url,
+    },
+  };
+
+  // 알림을 클릭했을 때 링크를 여는 이벤트 리스너를 추가합니다.
+  self.addEventListener("notificationclick", (event) => {
+    const urlToRedirect = event.notification.data.url;
+    event.notification.close();
+    event.waitUntil(self.clients.openWindow(urlToRedirect));
+  });
+
+  // Notification API를 사용하여 기기에서 알림을 표시합니다.
+  self.registration.showNotification(notificationTitle, notificationOptions);
+});


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #483
기존 FCM message payload의 Notification에 담겨있던 title과 body를 data로 이동시킵니다 (android 앱과의 호환성 확보를 위해서입니다).

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음 (알림 수신이 이전처럼 잘 됩니다!)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음