### PR TITLE
#254 `VirtualKeyboardDetector`에서 Ipad 감지 버그 해결

### DIFF
--- a/src/components/Skeleton/VirtualKeyboardDetector.tsx
+++ b/src/components/Skeleton/VirtualKeyboardDetector.tsx
@@ -7,11 +7,13 @@ const VirtualKeyboardDetector = () => {
   const setIsVKDetected = useSetRecoilState(isVirtualKeyboardDetectedAtom);
 
   const userAgent = navigator.userAgent.toLowerCase();
+  const maxTouchPoints = navigator.maxTouchPoints || 0;
   const isAndroid = userAgent.includes("android");
   const isIOS =
     userAgent.includes("iphone") ||
     userAgent.includes("ipad") ||
-    userAgent.includes("ipod");
+    userAgent.includes("ipod") ||
+    (userAgent.includes("macintosh") && maxTouchPoints > 1);
 
   useEffect(() => {
     /*


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #254 

IOS 13버전 이상에서 아이패드 사파리에서 `userAgent`가 "macintosh"로 표기되어
가상 키보드 올라옴 감지가 안되는 버그가 있었습니다.

이를 디바이스의 터치 가능 여부 인식으로 해결하였습니다.

# Blogs
 - https://minemanemo.tistory.com/101
 - https://s-b-c.tistory.com/11