### PR TITLE
#547 방 공유하기에 에브리타임에 글을 올릴 수 있는 템플릿 생성 후 복사 기능 추가

### DIFF
--- a/src/components/ModalPopup/Body/BodyRoomShare.tsx
+++ b/src/components/ModalPopup/Body/BodyRoomShare.tsx
@@ -129,9 +129,22 @@ const BodyRoomShare = ({ roomInfo, height }: BodyRoomShareProps) => {
             background="#FFE812"
           />
         </LinkKakaotalkShare>
-        <LinkCopy value={host + pathForShare} onCopy={onCopy}>
+        <LinkCopy
+          value={`🚕 ${date2str(
+            roomInfo.time,
+            "LLLL",
+            false
+          )} ${getLocationName(
+            roomInfo.from,
+            i18n.language
+          )} → ${getLocationName(
+            roomInfo.to,
+            i18n.language
+          )} 택시팟 구합니다!\n🚕 참여 링크: ${host + pathForShare}`}
+          onCopy={onCopy}
+        >
           <ButtonShare
-            text="링크복사"
+            text="초대 복사"
             icon={
               isCopied ? (
                 <CheckIcon style={{ fontSize: "16px" }} />

--- a/src/tools/moment.js
+++ b/src/tools/moment.js
@@ -16,7 +16,23 @@ const getToday10 = () => {
 
 const time2str = (num) => num.toString().padStart(2, "0");
 
-const date2str = (date, format = "LLLL") => moment(date).format(format);
+// includeYear: date string에 연도를 포함할 지 유무
+const date2str = (date, format = "LLLL", includeYear = true) => {
+  const locale = moment.locale();
+  const dateString = moment(date).format(format);
+
+  if (includeYear) {
+    return dateString;
+  }
+
+  if (locale === "ko") {
+    return dateString.replace(/[0-9]{4}년 /, "");
+  } else if (locale === "en") {
+    return dateString.replace(/, [0-9]{4}/, "");
+  } else {
+    return dateString;
+  }
+};
 
 export default moment;
 export { getToday, getToday10, time2str, date2str };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #547 
다른 플랫폼(예시: 에브리타임 택시 게시판, 손편지 등)에 방 정보를 공유할 수 있도록 아래와 같은 텍스트를 복사하는 기능을 제공합니다.
> 🚕 4월 26일 수요일 오전 2:50 갤러리아 타임월드 → 택시승강장 택시팟 구합니다!
> 🚕 참여 링크: http://localhost:3000/invite/644810b9e2724833e48b20af

기존에 잘 만들어진 링크 복사 기능을 약간만 발전시켰습니다. 👍 

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="451" alt="스크린샷 2023-04-26 오전 2 50 17" src="https://user-images.githubusercontent.com/46402016/234360415-53f1cdbc-4a7e-4020-b8fd-b0f70e87f2dc.png">
(방 공유 화면 스크린샷)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
