### PR TITLE
#569 [Bug] 홈페이지 - 방 클릭 시 페이지가 1로 초기화

### DIFF
--- a/src/hooks/usePageFromSearchParams.tsx
+++ b/src/hooks/usePageFromSearchParams.tsx
@@ -2,7 +2,7 @@ import qs from "qs";
 import { useCallback, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
-const usePageFromSearchParams = (totalPages: Number) => {
+const usePageFromSearchParams = (totalPages: number) => {
   const location = useLocation();
   const { search } = location;
 

--- a/src/pages/Home/RoomList.tsx
+++ b/src/pages/Home/RoomList.tsx
@@ -26,7 +26,7 @@ const RoomList = (props: RoomListProps) => {
             .map((room) => (
               <Link
                 key={room._id}
-                to={`/home/${room._id}`}
+                to={`/home/${room._id}?page=${currentPage}`}
                 replace
                 style={{ textDecoration: "none" }}
               >

--- a/src/pages/Home/RoomSection.tsx
+++ b/src/pages/Home/RoomSection.tsx
@@ -84,7 +84,10 @@ const RoomSection = ({ roomId }: RoomSectionProps) => {
       </Title>
       <SelectDate
         selectedDate={selectedDate}
-        onClick={([year, month, date]) => setSelectedDate([year, month, date])}
+        onClick={([year, month, date]) => {
+          history.replace("/home");
+          setSelectedDate([year, month, date]);
+        }}
       />
       <RoomList rooms={rooms} />
     </RLayout.R1>

--- a/src/pages/Home/RoomSection.tsx
+++ b/src/pages/Home/RoomSection.tsx
@@ -74,7 +74,9 @@ const RoomSection = ({ roomId }: RoomSectionProps) => {
     <RLayout.R1>
       <ModalRoomSelection
         isOpen={!!roomInfo}
-        onChangeIsOpen={() => history.replace("/home")}
+        onChangeIsOpen={() =>
+          history.replace("/home" + history.location.search)
+        }
         roomInfo={roomInfo}
       />
       <Title icon="taxi" header>


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #569 

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 모달을 열고 닫는 방식을 통일할 필요가 있어보여요. 홈페이지에서는 페이지를 이동하여 params로 roomId를 확인하는 반면에 검색 페이지에서는 일반 state로 관리하고 있어서 추후 혼란을 초래할 것만 같은 느낌적인 느낌.