### PR TITLE
#545.3 IOS 기기 모바일에서 홈 페이지 접근 시, 택시 앱 유도 창 띄우기

### DIFF
--- a/src/tools/trans.js
+++ b/src/tools/trans.js
@@ -3,7 +3,7 @@ import { firebaseConfig, s3BaseUrl } from "loadenv";
 const getS3Url = (x) => `${s3BaseUrl}${x}`;
 
 const getDynamicLink = (to, fallback = true) => {
-  const { host, androidPacakgeName, iosAppBundleId } =
+  const { host, androidPacakgeName, iosAppBundleId, appStoreId } =
     firebaseConfig?.dinamicLink || {};
   const { origin } = window.location;
 
@@ -12,7 +12,7 @@ const getDynamicLink = (to, fallback = true) => {
 
   return fallback
     ? `${host}?link=${encodedLink}&apn=${androidPacakgeName}&afl=${encodedLink}&ibi=${iosAppBundleId}&ifl=${encodedLink}&efr=1`
-    : `${host}?link=${encodedLink}&apn=${androidPacakgeName}&ibi=${iosAppBundleId}&efr=1`;
+    : `${host}?link=${encodedLink}&apn=${androidPacakgeName}&ibi=${iosAppBundleId}&isi=${appStoreId}&efr=1`;
 };
 
 const getLocationName = (location, langPreference) => {


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #545 

`getDynamicLink`  함수에 앱이 설치되어 있지 않은 경우 앱스토어로 이동하도록 `appStoreId`를 추가하였습니다.
