### PR TITLE
#585 초대 링크에서 페이지 로드 전 딥링크 작동

### DIFF
--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -105,7 +105,8 @@ const Skeleton = ({ children }: SkeletonProps) => {
   if (
     pathname.startsWith("/login") ||
     pathname.startsWith("/logout") ||
-    pathname.startsWith("/chatting")
+    pathname.startsWith("/chatting") ||
+    pathname.startsWith("/invite")
   ) {
     return (
       <Container>

--- a/src/pages/Home/RedirectToHome.tsx
+++ b/src/pages/Home/RedirectToHome.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from "react-router-dom";
+
+const RedirectToHome = () => <Redirect to="/home" />;
+
+export default RedirectToHome;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import { useHistory, useLocation, useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 
 import Footer from "components/Footer";
 import { ModalPrivacyPolicy } from "components/ModalPopup";
@@ -7,21 +6,10 @@ import { ModalPrivacyPolicy } from "components/ModalPopup";
 import InfoSection from "./InfoSection";
 import RoomSection from "./RoomSection";
 
-import { getDynamicLink } from "tools/trans";
-
 const Home = () => {
   const history = useHistory();
-  const { pathname } = useLocation();
   const { roomId: _roomId } = useParams<{ roomId: string }>();
   const roomId = _roomId === "privacyPolicy" ? null : _roomId;
-
-  useEffect(() => {
-    if (pathname === "/") history.replace("/home");
-    if (pathname.startsWith("/invite") && roomId) {
-      // dynamic link로 웹에서 앱으로 이동가능할 시 이동합니다.
-      window.location.href = getDynamicLink(`/home/${roomId}`);
-    }
-  }, [roomId, pathname]);
 
   const onChangeIsOpenPrivacyPolicy = () => history.replace("/home");
 

--- a/src/pages/Invite/index.tsx
+++ b/src/pages/Invite/index.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+
+import Loading from "components/Loading";
+
+import { getDynamicLink } from "tools/trans";
+
+const Invite = () => {
+  const { roomId } = useParams<{ roomId: string }>();
+
+  useEffect(() => {
+    // dynamic link로 웹에서 앱으로 이동가능할 시 이동합니다.
+    window.location.href = getDynamicLink(`/home/${roomId}`);
+  }, []);
+
+  return <Loading center />;
+};
+
+export default Invite;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,7 +13,17 @@ const routes = [
     exact: true,
   },
   {
-    path: ["/", "/home", "/home/:roomId", "/invite/:roomId"],
+    path: "/",
+    component: lazy(() => import("pages/Home/RedirectToHome")),
+    exact: true,
+  },
+  {
+    path: "/invite/:roomId",
+    component: lazy(() => import("pages/Invite")),
+    exact: true,
+  },
+  {
+    path: ["/home", "/home/:roomId"],
     component: lazy(() => import("pages/Home")),
     exact: true,
   },


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #585 

기존에는 초대 링크 접속 시, 방 모달이 렌더링 된 후 딥링크가 작동하였으나
방 모달 렌더링을 "invite" 페이지에서는 하지 않도록 수정하였습니다.