### PR TITLE
#580.5 `IOS` 앱 기기에서 `LinkCopy`가 작동하지 않는 버그 해결

### DIFF
--- a/src/components/Link/LinkCopy.tsx
+++ b/src/components/Link/LinkCopy.tsx
@@ -16,13 +16,11 @@ const LinkCopy = ({ children, value, onCopy }: LinkCopyProps) => {
   const setAlert = useSetRecoilState(alertAtom);
   const onClick = useCallback(() => {
     if (deviceType.startsWith("app/")) sendClipboardCopyEventToFlutter(value);
-    else {
-      if (!navigator.clipboard) {
-        setAlert("복사를 지원하지 않는 브라우저입니다.");
-        return;
-      }
-      navigator.clipboard.writeText(value);
+    if (!navigator.clipboard) {
+      setAlert("복사를 지원하지 않는 브라우저입니다.");
+      return;
     }
+    navigator.clipboard.writeText(value);
     onCopy?.(value);
   }, [value, onCopy]);
   return <a onClick={onClick}>{children}</a>;


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #580 

`IOS` 앱 기기에서 `LinkCopy`가 작동하지 않는 버그를 해결하였습니다.