### PR TITLE
`eventMode` 환경변수로 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ REACT_APP_IO_URL=[Socket.io server url(e.g. http://localhost:80)] # 주어지지
 REACT_APP_S3_URL=[aws s3 baseline url]
 REACT_APP_GA_TRACKING_ID=[google analytics tracking id]
 REACT_APP_FIREBASE_CONFIG=[firebase config JSON]
-EVENT_MODE=[event mode(e.g. 2023fall)]
+REACT_APP_EVENT_MODE=[event mode(e.g. 2023fall)]

--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,3 @@ REACT_APP_IO_URL=[Socket.io server url(e.g. http://localhost:80)] # 주어지지
 REACT_APP_S3_URL=[aws s3 baseline url]
 REACT_APP_GA_TRACKING_ID=[google analytics tracking id]
 REACT_APP_FIREBASE_CONFIG=[firebase config JSON]
-REACT_APP_EVENT_MODE=[event mode(e.g. 2023fall)]

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ REACT_APP_IO_URL=[Socket.io server url(e.g. http://localhost:80)] # 주어지지
 REACT_APP_S3_URL=[aws s3 baseline url]
 REACT_APP_GA_TRACKING_ID=[google analytics tracking id]
 REACT_APP_FIREBASE_CONFIG=[firebase config JSON]
+EVENT_MODE=[event mode(e.g. 2023fall)]

--- a/src/tools/loadenv.ts
+++ b/src/tools/loadenv.ts
@@ -17,7 +17,7 @@ export const kakaoSDKKey = env.REACT_APP_KAKAO_SDK_KEY; // optional
 export const gaTrackingId = env.REACT_APP_GA_TRACKING_ID; // optional
 export const firebaseConfig: Nullable<FirebaseConfig> =
   env.REACT_APP_FIREBASE_CONFIG && JSON.parse(env.REACT_APP_FIREBASE_CONFIG); // optional
-export const eventMode: Nullable<string> = undefined; // "2023fall";
+export const eventMode: Nullable<string> = env.EVENT_MODE; // optional. "2023fall"로 설정 가능
 
 // devicet-type 감지
 const userAgent = navigator.userAgent.toLowerCase();

--- a/src/tools/loadenv.ts
+++ b/src/tools/loadenv.ts
@@ -17,7 +17,7 @@ export const kakaoSDKKey = env.REACT_APP_KAKAO_SDK_KEY; // optional
 export const gaTrackingId = env.REACT_APP_GA_TRACKING_ID; // optional
 export const firebaseConfig: Nullable<FirebaseConfig> =
   env.REACT_APP_FIREBASE_CONFIG && JSON.parse(env.REACT_APP_FIREBASE_CONFIG); // optional
-export const eventMode: Nullable<string> = env.EVENT_MODE; // optional. "2023fall"로 설정 가능
+export const eventMode = env.REACT_APP_EVENT_MODE; // optional. "2023fall"로 설정 가능
 
 // devicet-type 감지
 const userAgent = navigator.userAgent.toLowerCase();

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -8,7 +8,7 @@ type Env = {
   REACT_APP_KAKAO_SDK_KEY?: string;
   REACT_APP_GA_TRACKING_ID?: string;
   REACT_APP_FIREBASE_CONFIG?: string;
-  EVENT_MODE?: string;
+  REACT_APP_EVENT_MODE?: string;
 };
 
 export type FirebaseConfig = {

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -8,6 +8,7 @@ type Env = {
   REACT_APP_KAKAO_SDK_KEY?: string;
   REACT_APP_GA_TRACKING_ID?: string;
   REACT_APP_FIREBASE_CONFIG?: string;
+  EVENT_MODE?: string;
 };
 
 export type FirebaseConfig = {


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #651 
`eventMode`의 값을 개발용 서버에서 변경해 테스트할 수 있게 하기 위해서 `eventMode` 값을 `REACT_APP_EVENT_MODE` 환경변수에 의해 설정될 수 있게 수정합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="470" alt="image" src="https://github.com/sparcs-kaist/taxi-front/assets/46402016/3bdefd0f-f4a3-4d7a-97c7-083e36bea009">

`process.env.REACT_APP_EVENT_MODE`="2023fall"

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
