### PR TITLE
#680.2 한가위 송편 이벤트 결과 공지 섹션 제거

### DIFF
--- a/src/pages/Home/EventSection/index.tsx
+++ b/src/pages/Home/EventSection/index.tsx
@@ -1,5 +1,4 @@
 import EventSection2023Fall from "./EventSection2023Fall";
-import EventSection2023FallResult from "./EventSection2023FallResult";
 import EventSection2023Spring from "./EventSection2023Spring";
 
 import { eventMode } from "tools/loadenv";
@@ -11,7 +10,7 @@ const EventSection = () => {
     case "2023fall":
       return <EventSection2023Fall />;
     default:
-      return <EventSection2023FallResult />;
+      return null;
   }
 };
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #680 

한가위 송편 이벤트 결과 공지 섹션을 홈페이지에서 더이상 보여주지 않습니다.