### PR TITLE
프로필 이미지 클릭 시 신고 모달 띄우기

### DIFF
--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, useState } from "react";
 
 import type { BotChat, LayoutType, UserChat } from "@/types/chat";
 
 import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 
+import { ModalChatReport } from "@/components/ModalPopup";
 import ProfileImage from "@/components/User/ProfileImage";
 
 import MessageAccount from "./MessageAccount";
@@ -58,7 +59,11 @@ type MessageSetProps = {
 };
 
 const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
+  const [isOpenReport, setIsOpenReport] = useState<boolean>(false);
   const { oid: userOid } = useValueRecoilState("loginInfo") || {};
+
+  const onClickReport = useCallback(() => setIsOpenReport(true), []);
+
   const authorId = chats?.[0]?.authorId;
   const authorProfileUrl =
     "authorProfileUrl" in chats?.[0] ? chats?.[0].authorProfileUrl : "";
@@ -135,48 +140,50 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
   };
 
   return (
-    <div css={style}>
-      <div css={styleProfileSection}>
-        {authorId !== userOid && (
-          <div
-            css={styleProfile}
-            onClick={() => {
-              /* @fixme @todo */
-            }}
-          >
-            {authorId === "bot" ? (
-              <TaxiIcon css={{ width: "100%", height: "100%" }} />
-            ) : (
-              <ProfileImage url={authorProfileUrl} />
-            )}
-          </div>
-        )}
-      </div>
-      <div css={styleMessageSection}>
-        {authorId !== userOid && (
-          <div css={styleName} className="selectable">
-            {authorName}
-          </div>
-        )}
-        {chats.map((chat, index) => (
-          <div key={getChatUniquewKey(chat)} css={styleMessageWrap}>
-            <div css={styleChat(chat.type)}>
-              <MessageBody
-                type={chat.type}
-                content={chat.content}
-                roomInfo={roomInfo}
-                color={authorId === userOid ? theme.white : theme.black}
-              />
+    <>
+      <div css={style}>
+        <div css={styleProfileSection}>
+          {authorId !== userOid && (
+            <div css={styleProfile} onClick={onClickReport}>
+              {authorId === "bot" ? (
+                <TaxiIcon css={{ width: "100%", height: "100%" }} />
+              ) : (
+                <ProfileImage url={authorProfileUrl} />
+              )}
             </div>
-            {index === chats.length - 1 && (
-              <div css={styleTime} className="selectable">
-                {dayjs(chat.time).format("H시 mm분")}
+          )}
+        </div>
+        <div css={styleMessageSection}>
+          {authorId !== userOid && (
+            <div css={styleName} className="selectable">
+              {authorName}
+            </div>
+          )}
+          {chats.map((chat, index) => (
+            <div key={getChatUniquewKey(chat)} css={styleMessageWrap}>
+              <div css={styleChat(chat.type)}>
+                <MessageBody
+                  type={chat.type}
+                  content={chat.content}
+                  roomInfo={roomInfo}
+                  color={authorId === userOid ? theme.white : theme.black}
+                />
               </div>
-            )}
-          </div>
-        ))}
+              {index === chats.length - 1 && (
+                <div css={styleTime} className="selectable">
+                  {dayjs(chat.time).format("H시 mm분")}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+      <ModalChatReport
+        roomInfo={roomInfo}
+        isOpen={isOpenReport}
+        onChangeIsOpen={setIsOpenReport}
+      />
+    </>
   );
 };
 

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -62,7 +62,7 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
   const [isOpenReport, setIsOpenReport] = useState<boolean>(false);
   const { oid: userOid } = useValueRecoilState("loginInfo") || {};
 
-  const onClickReport = useCallback(() => setIsOpenReport(true), []);
+  const onClickProfileImage = useCallback(() => setIsOpenReport(true), []);
 
   const authorId = chats?.[0]?.authorId;
   const authorProfileUrl =
@@ -151,7 +151,7 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
           {authorId !== userOid && (
             <div
               css={{ ...styleProfile, ...(!isBot && styleHover) }}
-              onClick={() => !isBot && onClickReport()}
+              onClick={() => !isBot && onClickProfileImage()}
             >
               {isBot ? (
                 <TaxiIcon css={{ width: "100%", height: "100%" }} />

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -101,6 +101,9 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
     alignItems: "flex-end",
     gap: "4px",
   };
+  const styleHover = {
+    cursor: "pointer",
+  };
   const styleChat = useCallback(
     (type: (UserChat | BotChat)["type"]) => ({
       maxWidth: "max(75%, 210px)",
@@ -144,13 +147,20 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
       <div css={style}>
         <div css={styleProfileSection}>
           {authorId !== userOid && (
-            <div css={styleProfile} onClick={onClickReport}>
+            <>
               {authorId === "bot" ? (
-                <TaxiIcon css={{ width: "100%", height: "100%" }} />
+                <div css={styleProfile}>
+                  <TaxiIcon css={{ width: "100%", height: "100%" }} />
+                </div>
               ) : (
-                <ProfileImage url={authorProfileUrl} />
+                <div
+                  css={{ ...styleProfile, ...styleHover }}
+                  onClick={onClickReport}
+                >
+                  <ProfileImage url={authorProfileUrl} />
+                </div>
               )}
-            </div>
+            </>
           )}
         </div>
         <div css={styleMessageSection}>

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -190,6 +190,7 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
         roomInfo={roomInfo}
         isOpen={isOpenReport}
         onChangeIsOpen={setIsOpenReport}
+        userOid={authorId}
       />
     </>
   );

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -69,6 +69,8 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
     "authorProfileUrl" in chats?.[0] ? chats?.[0].authorProfileUrl : "";
   const authorName = "authorName" in chats?.[0] ? chats?.[0].authorName : "";
 
+  const isBot = authorId === "bot";
+
   const style = {
     position: "relative" as any,
     display: "flex",
@@ -147,20 +149,16 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
       <div css={style}>
         <div css={styleProfileSection}>
           {authorId !== userOid && (
-            <>
-              {authorId === "bot" ? (
-                <div css={styleProfile}>
-                  <TaxiIcon css={{ width: "100%", height: "100%" }} />
-                </div>
+            <div
+              css={{ ...styleProfile, ...(!isBot && styleHover) }}
+              onClick={() => !isBot && onClickReport()}
+            >
+              {isBot ? (
+                <TaxiIcon css={{ width: "100%", height: "100%" }} />
               ) : (
-                <div
-                  css={{ ...styleProfile, ...styleHover }}
-                  onClick={onClickReport}
-                >
-                  <ProfileImage url={authorProfileUrl} />
-                </div>
+                <ProfileImage url={authorProfileUrl} />
               )}
-            </>
+            </div>
           )}
         </div>
         <div css={styleMessageSection}>

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -103,9 +103,7 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
     alignItems: "flex-end",
     gap: "4px",
   };
-  const styleHover = {
-    cursor: "pointer",
-  };
+
   const styleChat = useCallback(
     (type: (UserChat | BotChat)["type"]) => ({
       maxWidth: "max(75%, 210px)",
@@ -150,7 +148,7 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
         <div css={styleProfileSection}>
           {authorId !== userOid && (
             <div
-              css={{ ...styleProfile, ...(!isBot && styleHover) }}
+              css={{ ...styleProfile, cursor: !isBot ? "pointer" : undefined }}
               onClick={() => !isBot && onClickProfileImage()}
             >
               {isBot ? (

--- a/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectType.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectType.tsx
@@ -32,7 +32,7 @@ import EditRoundedIcon from "@mui/icons-material/EditRounded";
 type BodyChatReportSelectTypeProps = {
   roomInfo: Room;
   reportedId: Report["reportedId"];
-  clearReportedId: () => void;
+  setIsSelected: Dispatch<SetStateAction<boolean>>;
   setIsSubmitted: Dispatch<SetStateAction<boolean>>;
 };
 
@@ -45,7 +45,7 @@ const selectOptions = [
 const BodyChatReportSelectType = ({
   roomInfo,
   reportedId,
-  clearReportedId,
+  setIsSelected,
   setIsSubmitted,
 }: BodyChatReportSelectTypeProps) => {
   const axios = useAxios();
@@ -228,7 +228,7 @@ const BodyChatReportSelectType = ({
             borderRadius: "8px",
             ...theme.font14,
           }}
-          onClick={clearReportedId}
+          onClick={() => setIsSelected(false)}
         >
           이전
         </Button>

--- a/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectType.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectType.tsx
@@ -11,7 +11,6 @@ import {
 
 import type { Report } from "@/types/report";
 
-import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 import useIsTimeOver from "@/hooks/useIsTimeOver";
 import { useAxios } from "@/hooks/useTaxiAPI";
 
@@ -50,7 +49,6 @@ const BodyChatReportSelectType = ({
 }: BodyChatReportSelectTypeProps) => {
   const axios = useAxios();
   const setAlert = useSetRecoilState(alertAtom);
-  const { oid: userOid } = useValueRecoilState("loginInfo") || {};
   const wrapRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [height, setHeight] = useState<CSSProperties["height"]>("28px");
@@ -76,10 +74,8 @@ const BodyChatReportSelectType = ({
         ? "기타 사유를 입력해주세요."
         : type === "etc-reason" && !regExpTest.reportMsg(etcDetail)
         ? "기타 사유는 1500자 까지 입력이 허용됩니다."
-        : userOid === reportedUser?._id
-        ? "나 자신은 신고할 수 없습니다."
         : null,
-    [type, etcDetail, isDeparted, userOid, reportedUser]
+    [type, etcDetail, isDeparted, reportedUser]
   );
 
   const resizeEvent = useCallback(() => {

--- a/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectUser.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectUser.tsx
@@ -1,7 +1,8 @@
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction } from "react";
 
 import type { Report } from "@/types/report";
 
+import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 import useIsTimeOver from "@/hooks/useIsTimeOver";
 
 import Button from "@/components/Button";
@@ -15,17 +16,19 @@ import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 
 type BodyChatReportSelectUserProps = {
   roomInfo: Room;
+  reportedId: Nullable<Report["reportedId"]>;
   setReportedId: Dispatch<SetStateAction<Nullable<Report["reportedId"]>>>;
+  setIsSelected: Dispatch<SetStateAction<boolean>>;
   onChangeIsOpen?: (isOpen: boolean) => void;
 };
 
 const BodyChatReportSelectUser = ({
   roomInfo,
+  reportedId,
   setReportedId,
+  setIsSelected,
   onChangeIsOpen,
 }: BodyChatReportSelectUserProps) => {
-  const [selectedUser, setSelectedUser] =
-    useState<Nullable<Report["reportedId"]>>(null);
   const isDeparted = useIsTimeOver(dayServerToClient(roomInfo.time)); // 방 출발 여부
 
   const styleText = {
@@ -84,16 +87,16 @@ const BodyChatReportSelectUser = ({
           <div
             key={user._id}
             css={styleUser}
-            onClick={() => setSelectedUser(user._id)}
+            onClick={() => setReportedId(user._id)}
           >
             <div
               css={{
                 ...styleCheckBox,
                 background:
-                  selectedUser === user._id ? theme.purple : theme.purple_light,
+                  reportedId === user._id ? theme.purple : theme.purple_light,
               }}
             >
-              {selectedUser === user._id && (
+              {reportedId === user._id && (
                 <CheckRoundedIcon style={styleCheckBoxIcon} />
               )}
             </div>
@@ -122,8 +125,8 @@ const BodyChatReportSelectUser = ({
             borderRadius: "8px",
             ...theme.font14_bold,
           }}
-          onClick={() => setReportedId(selectedUser)}
-          disabled={!selectedUser}
+          onClick={() => setIsSelected(true)}
+          disabled={!reportedId}
         >
           다음
         </Button>

--- a/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectUser.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyChatReportSelectUser.tsx
@@ -29,6 +29,7 @@ const BodyChatReportSelectUser = ({
   setIsSelected,
   onChangeIsOpen,
 }: BodyChatReportSelectUserProps) => {
+  const { oid: userOid } = useValueRecoilState("loginInfo") || {};
   const isDeparted = useIsTimeOver(dayServerToClient(roomInfo.time)); // 방 출발 여부
 
   const styleText = {
@@ -83,26 +84,31 @@ const BodyChatReportSelectUser = ({
       <div css={styleText}>신고할 사용자를 선택해주세요.</div>
       <DottedLine />
       <div css={styleUsers}>
-        {roomInfo.part.map((user) => (
-          <div
-            key={user._id}
-            css={styleUser}
-            onClick={() => setReportedId(user._id)}
-          >
-            <div
-              css={{
-                ...styleCheckBox,
-                background:
-                  reportedId === user._id ? theme.purple : theme.purple_light,
-              }}
-            >
-              {reportedId === user._id && (
-                <CheckRoundedIcon style={styleCheckBoxIcon} />
-              )}
-            </div>
-            <User value={user} isDeparted={isDeparted} />
-          </div>
-        ))}
+        {roomInfo.part.map(
+          (user) =>
+            user._id !== userOid && (
+              <div
+                key={user._id}
+                css={styleUser}
+                onClick={() => setReportedId(user._id)}
+              >
+                <div
+                  css={{
+                    ...styleCheckBox,
+                    background:
+                      reportedId === user._id
+                        ? theme.purple
+                        : theme.purple_light,
+                  }}
+                >
+                  {reportedId === user._id && (
+                    <CheckRoundedIcon style={styleCheckBoxIcon} />
+                  )}
+                </div>
+                <User value={user} isDeparted={isDeparted} />
+              </div>
+            )
+        )}
       </div>
       <div css={styleButtons}>
         <Button

--- a/packages/web/src/components/ModalPopup/ModalChatReport.tsx
+++ b/packages/web/src/components/ModalPopup/ModalChatReport.tsx
@@ -24,14 +24,17 @@ const ModalChatReport = ({
 }: ModalChatReportProps) => {
   const [reportedId, setReportedId] =
     useState<Nullable<Report["reportedId"]>>();
+  const [isSelected, setIsSelected] = useState<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
 
   useEffect(() => {
     if (userOid && roomInfo.part.find((user) => user._id === userOid)) {
       setReportedId(userOid);
+      setIsSelected(true);
       setIsSubmitted(false);
     } else {
       setReportedId(undefined);
+      setIsSelected(false);
       setIsSubmitted(false);
     }
   }, [roomInfo, userOid, modalProps.isOpen]);
@@ -53,17 +56,19 @@ const ModalChatReport = ({
         <ReportGmailerrorredRoundedIcon style={styleIcon} />
         신고하기
       </div>
-      {!reportedId ? (
+      {!reportedId || !isSelected ? (
         <BodyChatReportSelectUser
           roomInfo={roomInfo}
+          reportedId={reportedId}
           setReportedId={setReportedId}
+          setIsSelected={setIsSelected}
           onChangeIsOpen={modalProps?.onChangeIsOpen}
         />
       ) : !isSubmitted ? (
         <BodyChatReportSelectType
           roomInfo={roomInfo}
           reportedId={reportedId}
-          clearReportedId={() => setReportedId(undefined)}
+          setIsSelected={setIsSelected}
           setIsSubmitted={setIsSubmitted}
         />
       ) : (


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #757 
- 채팅방에서 프로필 이미지 클릭 시, 신고하기 모달 띄우기 (신고하기 모달의 첫번째 단계는 건너뛰는 것으로 협의하였습니다. @intaericky)
- 신고하기 모달의 두번째 단계에서 이전 버튼 클릭 시, 첫번째 단계로 돌아가 전에 선택했었던 유저를 선택한 상태로 표시
- 신고 리스트에서 자기 자신 제거

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

https://github.com/sparcs-kaist/taxi-front/assets/48019789/ed03b8dd-f321-4956-99cf-c7f9ee967e84

