### PR TITLE
회원 탈퇴 채널톡 연결 컴포넌트

### DIFF
--- a/packages/web/src/hooks/skeleton/useChannelTalkEffect/channelService.js
+++ b/packages/web/src/hooks/skeleton/useChannelTalkEffect/channelService.js
@@ -42,6 +42,9 @@ class ChannelService {
   updateUser(options) {
     window.ChannelIO("updateUser", options);
   }
+  openChat(message) {
+    window.ChannelIO("openChat", undefined, message);
+  }
   shutdown() {
     window.ChannelIO("shutdown");
   }

--- a/packages/web/src/hooks/skeleton/useChannelTalkEffect/index.tsx
+++ b/packages/web/src/hooks/skeleton/useChannelTalkEffect/index.tsx
@@ -36,15 +36,4 @@ export default () => {
       });
     }
   }, [pathname, error]);
-
-  const openWithdraw = () => {
-    if (channelTalkPluginKey) {
-      ChannelService.openChat({
-        chatId: undefined,
-        message:
-          "스팍스 택시 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다: ",
-      });
-    }
-  };
-  return { openWithdraw };
 };

--- a/packages/web/src/hooks/skeleton/useChannelTalkEffect/index.tsx
+++ b/packages/web/src/hooks/skeleton/useChannelTalkEffect/index.tsx
@@ -36,4 +36,15 @@ export default () => {
       });
     }
   }, [pathname, error]);
+
+  const openWithdraw = () => {
+    if (channelTalkPluginKey) {
+      ChannelService.openChat({
+        chatId: undefined,
+        message:
+          "스팍스 택시 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다: ",
+      });
+    }
+  };
+  return { openWithdraw };
 };

--- a/packages/web/src/pages/Mypage/Menu.tsx
+++ b/packages/web/src/pages/Mypage/Menu.tsx
@@ -47,7 +47,7 @@ const getIcon = (icon: string) => {
       return <AlarmOffRoundedIcon style={styleIcon} />;
     case "logout":
       return <ExitToAppRoundedIcon style={styleIcon} />;
-    case "withdraw":
+    case "cancel_account":
       return <PersonRemoveRoundedIcon style={styleIcon} />;
     case "beta":
       return <StarRoundedIcon style={styleIcon} />;

--- a/packages/web/src/pages/Mypage/Menu.tsx
+++ b/packages/web/src/pages/Mypage/Menu.tsx
@@ -12,6 +12,7 @@ import ExitToAppRoundedIcon from "@mui/icons-material/ExitToAppRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 import KeyboardArrowLeftRoundedIcon from "@mui/icons-material/KeyboardArrowLeftRounded";
 import LanguageRoundedIcon from "@mui/icons-material/LanguageRounded";
+import PersonRemoveRoundedIcon from "@mui/icons-material/PersonRemoveRounded";
 import PortraitRoundedIcon from "@mui/icons-material/PortraitRounded";
 import StarRoundedIcon from "@mui/icons-material/StarRounded";
 
@@ -46,6 +47,8 @@ const getIcon = (icon: string) => {
       return <AlarmOffRoundedIcon style={styleIcon} />;
     case "logout":
       return <ExitToAppRoundedIcon style={styleIcon} />;
+    case "withdraw":
+      return <PersonRemoveRoundedIcon style={styleIcon} />;
     case "beta":
       return <StarRoundedIcon style={styleIcon} />;
   }

--- a/packages/web/src/pages/Mypage/index.tsx
+++ b/packages/web/src/pages/Mypage/index.tsx
@@ -78,7 +78,7 @@ const Mypage = () => {
     channelService.openChat({
       chatId: undefined,
       message:
-        "스팍스 택시 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다:\n",
+        "SPARCS Taxi 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다:\n",
     });
   }, []);
 
@@ -213,12 +213,12 @@ const Mypage = () => {
           </Menu>
           {userId && (
             <>
-              <Menu icon="withdraw" onClick={onClickWithdraw}>
-                {t("withdraw")}
-              </Menu>
               <LinkLogout>
                 <Menu icon="logout">{t("logout")}</Menu>
               </LinkLogout>
+              <Menu icon="withdraw" onClick={onClickWithdraw}>
+                {t("withdraw")}
+              </Menu>
             </>
           )}
         </div>

--- a/packages/web/src/pages/Mypage/index.tsx
+++ b/packages/web/src/pages/Mypage/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import useChannelTalkEffect from "@/hooks/skeleton/useChannelTalkEffect";
+import channelService from "@/hooks/skeleton/useChannelTalkEffect/channelService";
 import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 
 import AdaptiveDiv from "@/components/AdaptiveDiv";
@@ -65,7 +65,11 @@ const Mypage = () => {
   const onClickEventPolicy = useCallback(() => setIsOpenEventPolicy(true), []);
   const onClickMembers = useCallback(() => setOpenIsMembers(true), []);
   const onClickWithdraw = useCallback(() => {
-    useChannelTalkEffect().openWithdraw();
+    channelService.openChat({
+      chatId: undefined,
+      message:
+        "스팍스 택시 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다:\n",
+    });
   }, []);
 
   const styleProfImg = {

--- a/packages/web/src/pages/Mypage/index.tsx
+++ b/packages/web/src/pages/Mypage/index.tsx
@@ -75,11 +75,9 @@ const Mypage = () => {
   const onClickEventPolicy = useCallback(() => setIsOpenEventPolicy(true), []);
   const onClickMembers = useCallback(() => setOpenIsMembers(true), []);
   const onClickWithdraw = useCallback(() => {
-    channelService.openChat({
-      chatId: undefined,
-      message:
-        "SPARCS Taxi 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다:\n",
-    });
+    channelService.openChat(
+      "SPARCS Taxi 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다:\n"
+    );
   }, []);
 
   const styleProfImg = {

--- a/packages/web/src/pages/Mypage/index.tsx
+++ b/packages/web/src/pages/Mypage/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import useChannelTalkEffect from "@/hooks/skeleton/useChannelTalkEffect";
 import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 
 import AdaptiveDiv from "@/components/AdaptiveDiv";
@@ -63,6 +64,9 @@ const Mypage = () => {
   );
   const onClickEventPolicy = useCallback(() => setIsOpenEventPolicy(true), []);
   const onClickMembers = useCallback(() => setOpenIsMembers(true), []);
+  const onClickWithdraw = useCallback(() => {
+    useChannelTalkEffect().openWithdraw();
+  }, []);
 
   const styleProfImg = {
     width: "50px",
@@ -194,9 +198,14 @@ const Mypage = () => {
             {t("credit")}
           </Menu>
           {userId && (
-            <LinkLogout>
-              <Menu icon="logout">{t("logout")}</Menu>
-            </LinkLogout>
+            <>
+              <Menu icon="withdraw" onClick={onClickWithdraw}>
+                {t("withdraw")}
+              </Menu>
+              <LinkLogout>
+                <Menu icon="logout">{t("logout")}</Menu>
+              </LinkLogout>
+            </>
           )}
         </div>
       </WhiteContainer>

--- a/packages/web/src/pages/Mypage/index.tsx
+++ b/packages/web/src/pages/Mypage/index.tsx
@@ -25,7 +25,7 @@ import WhiteContainerSuggestLogin from "@/components/WhiteContainer/WhiteContain
 
 import Menu from "./Menu";
 
-import { eventMode, isDev } from "@/tools/loadenv";
+import { deviceType, eventMode, isDev } from "@/tools/loadenv";
 import theme from "@/tools/theme";
 import { isNotificationOn } from "@/tools/trans";
 
@@ -74,7 +74,7 @@ const Mypage = () => {
   );
   const onClickEventPolicy = useCallback(() => setIsOpenEventPolicy(true), []);
   const onClickMembers = useCallback(() => setOpenIsMembers(true), []);
-  const onClickWithdraw = useCallback(() => {
+  const onClickCancelAccount = useCallback(() => {
     channelService.openChat(
       "SPARCS Taxi 서비스의 계정 탈퇴를 신청하고 싶습니다.\n신청 사유는 다음과 같습니다:\n"
     );
@@ -210,14 +210,14 @@ const Mypage = () => {
             {t("credit")}
           </Menu>
           {userId && (
-            <>
-              <LinkLogout>
-                <Menu icon="logout">{t("logout")}</Menu>
-              </LinkLogout>
-              <Menu icon="withdraw" onClick={onClickWithdraw}>
-                {t("withdraw")}
-              </Menu>
-            </>
+            <LinkLogout>
+              <Menu icon="logout">{t("logout")}</Menu>
+            </LinkLogout>
+          )}
+          {userId && deviceType.startsWith("app/") && (
+            <Menu icon="cancel_account" onClick={onClickCancelAccount}>
+              {t("cancel_account")}
+            </Menu>
           )}
         </div>
       </WhiteContainer>

--- a/packages/web/src/pages/Mypage/langs/en.json
+++ b/packages/web/src/pages/Mypage/langs/en.json
@@ -16,6 +16,7 @@
   "terms_privacy": "Collection and Use of Personal Information",
   "privacy_policy": "Privacy Policy",
   "credit": "Credit",
+  "withdraw": "Withdraw Account",
   "logout": "Logout",
   "page_modify": {
     "cancel": "Cancel",

--- a/packages/web/src/pages/Mypage/langs/en.json
+++ b/packages/web/src/pages/Mypage/langs/en.json
@@ -16,7 +16,7 @@
   "terms_privacy": "Collection and Use of Personal Information",
   "privacy_policy": "Privacy Policy",
   "credit": "Credit",
-  "withdraw": "Withdraw Account",
+  "cancel_account": "Cancel Account",
   "logout": "Logout",
   "page_modify": {
     "cancel": "Cancel",

--- a/packages/web/src/pages/Mypage/langs/ko.json
+++ b/packages/web/src/pages/Mypage/langs/ko.json
@@ -16,7 +16,7 @@
   "terms_privacy": "개인정보 수집 및 이용",
   "privacy_policy": "개인정보 처리방침",
   "credit": "만든 사람들",
-  "withdraw": "회원 탈퇴하기",
+  "cancel_account": "회원 탈퇴하기",
   "logout": "로그아웃",
   "page_modify": {
     "cancel": "취소",

--- a/packages/web/src/pages/Mypage/langs/ko.json
+++ b/packages/web/src/pages/Mypage/langs/ko.json
@@ -16,6 +16,7 @@
   "terms_privacy": "개인정보 수집 및 이용",
   "privacy_policy": "개인정보 처리방침",
   "credit": "만든 사람들",
+  "withdraw": "회원 탈퇴하기",
   "logout": "로그아웃",
   "page_modify": {
     "cancel": "취소",


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #767 
[https://developers.channel.io/reference/web-channelio-kr](url) 채널톡 개발 문서에 의하면 openChat을 통해 message를 미리 채워서 채팅창을 열게 할 수 있다고 합니다. 

### 변경 사항
앱 환경에서만 보이도록 수정했습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/sparcs-kaist/taxi-front/assets/47024715/8bbe228d-1640-48db-9805-6a5a778053ad)
![image](https://github.com/sparcs-kaist/taxi-front/assets/47024715/7b51b1a8-d1cf-426a-a356-34422678be44)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->
- [x] 로컬에서 채널톡 api key가 없어서 dev나 기타 방향을 통해 실제로 채팅창이 의도된 방향으로 잘 뜨는지 알아봐야 합니다.
- [x] 회원 탈퇴 신청 텍스트를 수정해야 합니다. 
