### PR TITLE
#773 채팅 140자 넘으면 입력 막기 & 글자 수 circular progress bar로 표시

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,6 +20,7 @@
     "prop-types": "^15.8.1",
     "qs": "^6.11.0",
     "react": "^18.2.0",
+    "react-circular-progressbar": "^2.1.0",
     "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-ga4": "^1.4.1",

--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -93,12 +93,14 @@ const BodyText = ({
       if (isSendingMessage) refreshTextArea();
       setIsMessageValidState(getIsMessageValid(textareaRef.current.value));
 
-      onTextChange(
-        textareaRef.current.value.length > 140
-          ? 140
-          : textareaRef.current.value.length
-      );
-      // 키보드를 쭉 눌러서 입력하면, max + 1번째 글자에 oninput이 먼저 호출된 후에 입력이 막혀서 숫자가 max + 1로 뜰 때가 있습니다.. 우선 이렇게 막아두겠습니다
+      if (textareaRef.current.value.length > maxChatMsgLength) {
+        textareaRef.current.value = textareaRef.current.value.substring(
+          0,
+          maxChatMsgLength
+        );
+      }
+
+      onTextChange(textareaRef.current.value.length);
 
       if (isEnterPressed.current && !isShiftPressed.current) {
         onSend();
@@ -128,7 +130,7 @@ const BodyText = ({
     if (textareaRef.current) wrapRef.current.removeChild(textareaRef.current);
     const textarea = document.createElement("textarea");
     textarea.oninput = onChange;
-    textarea.maxLength = maxChatMsgLength;
+    // textarea.maxLength = maxChatMsgLength;
     textarea.addEventListener("keydown", onKeyDown);
     textarea.addEventListener("keyup", onKeyUp);
     textarea.placeholder = "채팅을 입력해주세요";

--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -11,13 +11,13 @@ import theme from "@/tools/theme";
 type BodyTextProps = {
   sendMessage: ReturnType<typeof useSendMessage>;
   onTextChange: (msgLength: number) => void; // 글자 수를 부모에게 전달하여 circular progressbar에 사용
-  maxChatMsgLength: number; // 채팅 입력 최대 길이입니다.
+  maxChatLength: number;
 };
 
 const BodyText = ({
   sendMessage,
   onTextChange,
-  maxChatMsgLength,
+  maxChatLength,
 }: BodyTextProps) => {
   const wrapRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>();
@@ -93,10 +93,10 @@ const BodyText = ({
       if (isSendingMessage) refreshTextArea();
       setIsMessageValidState(getIsMessageValid(textareaRef.current.value));
 
-      if (textareaRef.current.value.length > maxChatMsgLength) {
+      if (!regExpTest.chatMsgLength(textareaRef.current.value)) {
         textareaRef.current.value = textareaRef.current.value.substring(
           0,
-          maxChatMsgLength
+          maxChatLength
         );
       }
 

--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -10,9 +10,10 @@ import theme from "@/tools/theme";
 
 type BodyTextProps = {
   sendMessage: ReturnType<typeof useSendMessage>;
+  onTextChange: (msgLength: number) => void; // 글자 수를 부모에게 전달하여 circular progressbar에 사용
 };
 
-const BodyText = ({ sendMessage }: BodyTextProps) => {
+const BodyText = ({ sendMessage, onTextChange }: BodyTextProps) => {
   const wrapRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>();
   const [height, setHeight] = useState<CSS["height"]>("32px");
@@ -46,7 +47,11 @@ const BodyText = ({ sendMessage }: BodyTextProps) => {
     useState<boolean>(false);
   const getIsMessageValid = useCallback(
     (message: string): boolean => {
-      return regExpTest.chatMsg(message) && regExpTest.chatMsgLength(message) && !isSendingMessage
+      return (
+        regExpTest.chatMsg(message) &&
+        regExpTest.chatMsgLength(message) &&
+        !isSendingMessage
+      );
     },
     [isSendingMessage]
   );
@@ -82,6 +87,8 @@ const BodyText = ({ sendMessage }: BodyTextProps) => {
       if (!textareaRef.current) return;
       if (isSendingMessage) refreshTextArea();
       setIsMessageValidState(getIsMessageValid(textareaRef.current.value));
+
+      onTextChange(textareaRef.current.value.length);
 
       if (isEnterPressed.current && !isShiftPressed.current) {
         onSend();

--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -11,9 +11,14 @@ import theme from "@/tools/theme";
 type BodyTextProps = {
   sendMessage: ReturnType<typeof useSendMessage>;
   onTextChange: (msgLength: number) => void; // 글자 수를 부모에게 전달하여 circular progressbar에 사용
+  maxChatMsgLength: number; // 채팅 입력 최대 길이입니다.
 };
 
-const BodyText = ({ sendMessage, onTextChange }: BodyTextProps) => {
+const BodyText = ({
+  sendMessage,
+  onTextChange,
+  maxChatMsgLength,
+}: BodyTextProps) => {
   const wrapRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>();
   const [height, setHeight] = useState<CSS["height"]>("32px");

--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -93,7 +93,12 @@ const BodyText = ({
       if (isSendingMessage) refreshTextArea();
       setIsMessageValidState(getIsMessageValid(textareaRef.current.value));
 
-      onTextChange(textareaRef.current.value.length);
+      onTextChange(
+        textareaRef.current.value.length > 140
+          ? 140
+          : textareaRef.current.value.length
+      );
+      // 키보드를 쭉 눌러서 입력하면, max + 1번째 글자에 oninput이 먼저 호출된 후에 입력이 막혀서 숫자가 max + 1로 뜰 때가 있습니다.. 우선 이렇게 막아두겠습니다
 
       if (isEnterPressed.current && !isShiftPressed.current) {
         onSend();
@@ -123,6 +128,7 @@ const BodyText = ({
     if (textareaRef.current) wrapRef.current.removeChild(textareaRef.current);
     const textarea = document.createElement("textarea");
     textarea.oninput = onChange;
+    textarea.maxLength = maxChatMsgLength;
     textarea.addEventListener("keydown", onKeyDown);
     textarea.addEventListener("keyup", onKeyUp);
     textarea.placeholder = "채팅을 입력해주세요";

--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -45,8 +45,9 @@ const BodyText = ({ sendMessage }: BodyTextProps) => {
   const [isMessageValidState, setIsMessageValidState] =
     useState<boolean>(false);
   const getIsMessageValid = useCallback(
-    (message: string): boolean =>
-      regExpTest.chatMsg(message) && !isSendingMessage,
+    (message: string): boolean => {
+      return regExpTest.chatMsg(message) && regExpTest.chatMsgLength(message) && !isSendingMessage
+    },
     [isSendingMessage]
   );
   useEffect(

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
-import { Direction } from "react-toastify/dist/utils";
 
 import useSendMessage from "@/hooks/chat/useSendMessage";
 

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -1,7 +1,3 @@
-import { useState } from "react";
-import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
-import "react-circular-progressbar/dist/styles.css";
-
 import useSendMessage from "@/hooks/chat/useSendMessage";
 
 import BodyImage from "./BodyImage";
@@ -21,67 +17,8 @@ const InputText = ({
   sendMessage,
 }: InputTextProps) => {
   const inputMode = uploadedImage ? "image" : "text";
-  const [chatMsgLength, setChatMsgLength] = useState<number>(0);
-  const maxChatMsgLength = 140; // 채팅 입력 최대 길이입니다.
   const children = {
-    text: (
-      <div
-        style={{
-          display: "flex",
-          flex: 1,
-          flexDirection: "row",
-          alignItems: "center",
-        }}
-      >
-        <div
-          style={{
-            width: "28px",
-            height: "28px",
-            marginLeft: "0px",
-            position: "relative",
-          }}
-        >
-          <CircularProgressbar
-            value={chatMsgLength}
-            maxValue={maxChatMsgLength}
-            strokeWidth={10}
-            styles={buildStyles({
-              // Rotation of path and trail, in number of turns (0-1)
-              rotation: 0.25,
-
-              // Whether to use rounded or flat corners on the ends - can use 'butt' or 'round'
-              strokeLinecap: "butt",
-
-              // Text size
-              textSize: "28px",
-
-              // How long animation takes to go from one chatMsgLength to another, in seconds
-              pathTransitionDuration: 0.2,
-
-              // Can specify path transition in more detail, or remove it entirely
-              // pathTransition: 'none',
-
-              // Colors
-              pathColor: `${
-                chatMsgLength < maxChatMsgLength
-                  ? `rgba(110, 54, 120)`
-                  : `rgba(180, 0, 0)`
-              }`,
-              textColor: "#000000",
-              trailColor: "#d6d6d6",
-              backgroundColor: "#3e98c7",
-            })}
-          />
-        </div>
-        <div style={{ flex: 1 }}>
-          <BodyText
-            sendMessage={sendMessage}
-            onTextChange={setChatMsgLength}
-            maxChatLength={maxChatMsgLength}
-          />
-        </div>
-      </div>
-    ),
+    text: <BodyText sendMessage={sendMessage} />,
     image: (
       <BodyImage
         uploadedImage={uploadedImage as File}

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -34,7 +34,14 @@ const InputText = ({
           alignItems: "center",
         }}
       >
-        <div style={{ width: "20px", height: "20px", marginLeft: "5px" }}>
+        <div
+          style={{
+            width: "28px",
+            height: "28px",
+            marginLeft: "0px",
+            position: "relative",
+          }}
+        >
           <CircularProgressbar
             value={chatMsgLength}
             maxValue={maxChatMsgLength}

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -77,7 +77,7 @@ const InputText = ({
           <BodyText
             sendMessage={sendMessage}
             onTextChange={setChatMsgLength}
-            maxChatMsgLength={maxChatMsgLength}
+            maxChatLength={maxChatMsgLength}
           />
         </div>
       </div>

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -45,8 +45,7 @@ const InputText = ({
           <CircularProgressbar
             value={chatMsgLength}
             maxValue={maxChatMsgLength}
-            text={`${chatMsgLength}`}
-            strokeWidth={20}
+            strokeWidth={10}
             styles={buildStyles({
               // Rotation of path and trail, in number of turns (0-1)
               rotation: 0.25,

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -69,7 +69,11 @@ const InputText = ({
           />
         </div>
         <div style={{ flex: 1 }}>
-          <BodyText sendMessage={sendMessage} onTextChange={setChatMsgLength} />
+          <BodyText
+            sendMessage={sendMessage}
+            onTextChange={setChatMsgLength}
+            maxChatMsgLength={maxChatMsgLength}
+          />
         </div>
       </div>
     ),

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -1,3 +1,8 @@
+import { useState } from "react";
+import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
+import "react-circular-progressbar/dist/styles.css";
+import { Direction } from "react-toastify/dist/utils";
+
 import useSendMessage from "@/hooks/chat/useSendMessage";
 
 import BodyImage from "./BodyImage";
@@ -17,8 +22,57 @@ const InputText = ({
   sendMessage,
 }: InputTextProps) => {
   const inputMode = uploadedImage ? "image" : "text";
+  const [chatMsgLength, setChatMsgLength] = useState<number>(0);
+  const maxChatMsgLength = 140; // 채팅 입력 최대 길이입니다.
   const children = {
-    text: <BodyText sendMessage={sendMessage} />,
+    text: (
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          flexDirection: "row",
+          alignItems: "center",
+        }}
+      >
+        <div style={{ width: "20px", height: "20px", marginLeft: "5px" }}>
+          <CircularProgressbar
+            value={chatMsgLength}
+            maxValue={maxChatMsgLength}
+            text={`${chatMsgLength}`}
+            strokeWidth={20}
+            styles={buildStyles({
+              // Rotation of path and trail, in number of turns (0-1)
+              rotation: 0.25,
+
+              // Whether to use rounded or flat corners on the ends - can use 'butt' or 'round'
+              strokeLinecap: "butt",
+
+              // Text size
+              textSize: "28px",
+
+              // How long animation takes to go from one chatMsgLength to another, in seconds
+              pathTransitionDuration: 0.2,
+
+              // Can specify path transition in more detail, or remove it entirely
+              // pathTransition: 'none',
+
+              // Colors
+              pathColor: `${
+                chatMsgLength < maxChatMsgLength
+                  ? `rgba(110, 54, 120)`
+                  : `rgba(180, 0, 0)`
+              }`,
+              textColor: "#000000",
+              trailColor: "#d6d6d6",
+              backgroundColor: "#3e98c7",
+            })}
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <BodyText sendMessage={sendMessage} onTextChange={setChatMsgLength} />
+        </div>
+      </div>
+    ),
     image: (
       <BodyImage
         uploadedImage={uploadedImage as File}

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/MessageText.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/MessageText.tsx
@@ -12,7 +12,7 @@ const MessageText = ({ text, color }: MessageTextProps) => (
       color,
       wordBreak: "break-all",
       ...theme.font14,
-      whiteSpace: "pre-line",
+      whiteSpace: "break-spaces",
     }}
     className="selectable"
   >

--- a/packages/web/src/hooks/chat/useSendMessage.tsx
+++ b/packages/web/src/hooks/chat/useSendMessage.tsx
@@ -26,7 +26,7 @@ export default (
         if (["text", "account"].includes(type)) {
           // 메시지가 정규식 검사에서 통과하지 못했다면 전송을 막습니다.
           if (!text) throw new Error();
-          if (type === "text" && !regExpTest.chatMsg(text)) throw new Error();
+          if (type === "text" && !regExpTest.chatMsg(text) && !regExpTest.chatMsgLength(text)) throw new Error();
           if (type === "account" && !regExpTest.account(text))
             throw new Error();
 

--- a/packages/web/src/tools/regExpTest.js
+++ b/packages/web/src/tools/regExpTest.js
@@ -3,6 +3,7 @@
 
 const chatMsg = (x) => RegExp("^\\s{0,}\\S{1}[\\s\\S]{0,}$").test(x);
 const chatMsgLength = (x) => RegExp("^[\\s\\S]{1,140}$").test(x);
+// chatMsgLength 수정 시, packages/web/components/Chat/MessageForm/InputText/BodyText.tsx의 maxChatMsgLength 도 수정해 주세요
 
 const nickname = (x) => {
   return RegExp("^[A-Za-z가-힣ㄱ-ㅎㅏ-ㅣ0-9-_ ]{3,25}$").test(x);

--- a/packages/web/src/tools/regExpTest.js
+++ b/packages/web/src/tools/regExpTest.js
@@ -1,7 +1,8 @@
 // 모든 정규식들은 아래 링크의 규칙을 기반으로 함
 // https://www.notion.so/sparcs/Input-value-Regular-Expression-4f3e778c3b884cfe9a1b5a733c8da8fb
 
-const chatMsg = (x) => RegExp("^[\\s\\S]{1,500}$").test(x);
+const chatMsg = (x) => RegExp("^\\s{0,}\\S{1}[\\s\\S]{0,}$").test(x);
+const chatMsgLength = (x) => RegExp("^[\\s\\S]{1,140}$").test(x);
 
 const nickname = (x) => {
   return RegExp("^[A-Za-z가-힣ㄱ-ㅎㅏ-ㅣ0-9-_ ]{3,25}$").test(x);
@@ -31,6 +32,7 @@ const account = (x) => {
 
 export default {
   chatMsg,
+  chatMsgLength,
   nickname,
   phoneNumber,
   roomName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      react-circular-progressbar:
+        specifier: ^2.1.0
+        version: 2.1.0(react@18.2.0)
       react-cookie:
         specifier: ^4.1.1
         version: 4.1.1(react@18.2.0)
@@ -12749,6 +12752,14 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    dev: false
+
+  /react-circular-progressbar@2.1.0(react@18.2.0):
+    resolution: {integrity: sha512-xp4THTrod4aLpGy68FX/k1Q3nzrfHUjUe5v6FsdwXBl3YVMwgeXYQKDrku7n/D6qsJA9CuunarAboC2xCiKs1g==}
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #773

140자 길이 제한을 구현하고, 향후 길이 제한을 바꿀 수 있도록 하였으며, react-circular-progressbar를 사용하여 현재 글자 수를 보기 쉽게 나타냅니다.

progressbar의 위치, 크기, margin 등이 과연 적절한가, 전체 리디자인 예정이기는 해도 style 변경 사항이 디자인 시스템의 체계를 너무 갖추지 않은 건 아닌가, state 사용이나 기타 등등 코드의 전체적인 구조와 맞지 않는 점은 없는가, 등을 중점적으로 리뷰해주시면 감사하겠습니다!

## 앞으로 최대 글자 수를 수정하려면?
1. packages/web/src/tools/regExpTest.js 의 `chatMsgLength` 정규 표현식을 수정합니다.
2. 이에 더해, packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx 의 `maxChatMsgLength` 변수 값도 함께 수정해 줍니다.

## 코드 수정 사항 설명
### 최신 버전 (2024.07.07.)
props에 대한 변경 사항을 모두 없애고, BodyText.tsx에서만 해결할 수 있도록 수정하였습니다.
리뷰 내용을 적용하면서, Progress Bar가 아랫쪽에 정렬되게 할 방법을 고민한 결과. BodyText.tsx와 index.tsx의 수정사항을 모두 없앤 후에, (정규 표현식 등의 변경 사항은 그대로입니다) 아래의 사항을 적용하였습니다. 
1. `chatMsgLength`라는 state와 `maxChatMsgLength`라는 변수를 BodyText 안에 선언합니다.
3. CircularProgressBar를 BodyText에서 사용합니다. 즉 이제 BodyText 안에 CircularProgressBar, 입력 칸, ButtonSend가 함께 들어있게 된 것입니다. CircularProgressBar를 여기 넣게 되면서, Style 수정이 일부 들어갔습니다. 새롭게 디자인한 style들은 모두 css-in-js를 적용하도록 맞추었습니다.
4. onChange에서 현재 글자 수와 `maxChatMsgLength`를 비교하여, 넘어가면 최대 글자수에 맞게 자릅니다. (연속 입력이나 긴 텍스트 붙여넣기의 경우에도 최대 글자수(현재 140)에 맞게 조정됩니다)
5. CircularProgressBar는 `chatMsgLength` state 값에 따라 그림을 그립니다.

### (이전 버전 (~봄학기))
packages/web/src/components/Chat/MessageForm/InputText/index.tsx
의 InputText 안에 정의된 maxChatMsgLength 길이를 넘지 못하도록 합니다.
이를 구현하기 위해, BodyText의 BodyTextProps를 변경하여, 부모가 자식인 BodyText에게 본인의 함수를 넘겨줌으로써 textarea 안의 내용이 변경될 때마다 부모 안에 정의된 progress bar가 바뀌도록 하였습니다. 또한 BodyText에서 props로 max 길이를 전달 받아, index.tsx에서의 maxChatMsgLength 변경만으로 모든 로직에 max 길이의 변경 사항이 반영되도록 하였습니다.

index.tsx의 style 구조를 조금 많이 바꿨습니다. flexbox를 사용하여 progress bar와 입력 칸이 가로로 배치되도록 하는 과정에서 변화가 있었습니다 

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

### 최신 디자인
(네이비색 점은 제 크롬 확장 프로그램 때문이라 무시하셔도 됩니다)
학기 중 회의 결과 (bar 두께 줄이기, 아래로 정렬, 글자 수 표시하지 않기) 반영
![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/377d87ec-3eda-4cc8-a4f6-cd94bc63a9c4)
![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/349ff609-7fc4-4e9d-b45c-23ee0ff526a6)


### (이전 디자인 기준)
아래와 같이 react-circular-progressbar를 사용하여 140자 제한 중 얼마나 사용했는지 보여줍니다.
![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/ccdbd33f-fb72-4602-8cd6-52c7331989e3)

그리고 140자가 넘으면 이렇게 되고 입력이 더이상 되지 않습니다. 140이라는 숫자는 위에 서술한 것과 같이, 바꿀 수 있습니다. 글자수 정책 변경 시, 앞으로는 정규식 외에도 이 부분을 함께 수정해주어야 합니다.
![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/75662f71-b28a-469d-9fe3-547c799273fc)


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
