### PR TITLE
#778 홈 화면 방 팝업에서 참여 중인 방 선택 시 바로가기 버튼 추가

### DIFF
--- a/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
@@ -130,6 +130,7 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
       history.push(`/myroom/${roomInfo._id}`);
       return;
     }
+    // 여기부터는 이미 참여 중인 방이 아닌 경우의 로직입니다.
     if (onCall.current) return;
     onCall.current = true;
     await axios({
@@ -217,7 +218,7 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
           }}
           onClick={requestJoin}
         >
-          {isDepart
+          {isDepart && !isAlreadyPart
             ? "출발 시각이 현재 이전인 방은 참여할 수 없습니다"
             : isAlreadyPart
             ? "이미 참여 중입니다 : 바로가기"

--- a/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
@@ -125,6 +125,11 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
   const isDepart = useIsTimeOver(dayServerToClient(roomInfo.time)); // 방 출발 여부
 
   const requestJoin = useCallback(async () => {
+    if (isAlreadyPart) {
+      // 이미 참여 중인 방에서 버튼을 누르면 API 호출 관련 로직을 건너뛰고 해당 방으로 이동합니다.
+      history.push(`/myroom/${roomInfo._id}`);
+      return;
+    }
     if (onCall.current) return;
     onCall.current = true;
     await axios({
@@ -204,7 +209,7 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
       {isLogin || isRoomFull || isDepart ? (
         <Button
           type="purple"
-          disabled={isRoomFull || isDepart || isAlreadyPart || isMaxPart}
+          disabled={isRoomFull || isDepart || isMaxPart}
           css={{
             padding: "10px 0 9px",
             borderRadius: "8px",
@@ -213,7 +218,7 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
           onClick={requestJoin}
         >
           {isAlreadyPart
-            ? "이미 참여 중입니다"
+            ? "참여 중인 방 - 바로가기"
             : isDepart
             ? "출발 시각이 현재 이전인 방은 참여할 수 없습니다"
             : isRoomFull

--- a/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
@@ -209,7 +209,7 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
       {isLogin || isRoomFull || isDepart ? (
         <Button
           type="purple"
-          disabled={isRoomFull || isDepart || isMaxPart}
+          disabled={isRoomFull || (isDepart && !isAlreadyPart) || isMaxPart}
           css={{
             padding: "10px 0 9px",
             borderRadius: "8px",
@@ -217,10 +217,10 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
           }}
           onClick={requestJoin}
         >
-          {isAlreadyPart
-            ? "참여 중인 방 - 바로가기"
-            : isDepart
+          {isDepart
             ? "출발 시각이 현재 이전인 방은 참여할 수 없습니다"
+            : isAlreadyPart
+            ? "참여 중인 방 - 바로가기"
             : isRoomFull
             ? "남은 인원이 0명인 방은 참여할 수 없습니다"
             : isMaxPart

--- a/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
@@ -220,7 +220,7 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
           {isDepart
             ? "출발 시각이 현재 이전인 방은 참여할 수 없습니다"
             : isAlreadyPart
-            ? "참여 중인 방 - 바로가기"
+            ? "이미 참여 중입니다 : 바로가기"
             : isRoomFull
             ? "남은 인원이 0명인 방은 참여할 수 없습니다"
             : isMaxPart


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #778 

### 구현한 것
packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx 를 수정하여,
1) 이미 참여 중인 방의 경우에도 활성화된 버튼이 나타나도록 하였으며
2) requestJoin 을 수정하여, 해당 버튼을 누르면 history.push를 사용하여 바로 방으로 이동하는 로직을 추가하였습니다.

### 리뷰 요청
requestJoin을 수정하면서, 이미 참여 중인 방은 API 호출이 필요 없기에 기존의 코드를 모두 무시하도록 하였습니다. requestJoin의 수정 사항이 적절한지를 중심으로 리뷰해주시면 감사하겠습니다.

### 논의 거리
1. 홈에서 모달을 띄운 채로 다른 창에서 탑승 취소해버리면, 추후에 모달에서 버튼을 누르면 방 참여(또는 존재) 여부를 검증하지 않고 url을 이동하기에 무한 로딩이 뜹니다. 이것을 검증하기 위해 API 콜을 날리는 게 좋은지, 아니면 이런 극단적인 경우를 위해 API 콜을 낭비하지 않는 게 좋은지 논의하고 싶습니다.
2. 11시 10분 출발 방은 11시 10분 59초까지 홈 화면에 보이는 것 같습니다. 이로 인해 홈 화면에 보이지만, isDepart로 인해 (참여 중인 경우의 바로가기 버튼도 포함) 버튼이 비활성화 되어 있는 상태가 1분간 지속됩니다. 이것이 새로운 이슈로서 논의되어야 할 것 같습니다.
우선은 이 PR에 대한 추가 커밋을 통해, 그 1분 동안 이미 참여한 방이라면 비활성화 버튼 대신 바로가기 버튼이 뜨도록 하는 코드를 올려두었습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

### 수정 전
![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/46621351-173f-4879-a6e6-bff56a1d06c0)

### 수정 후
![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/4981ae19-4571-42f4-9d7e-c11b835c5b48)

### 피드백 반영 : 버튼 메시지 수정
![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/28106968-a31c-4567-be8c-b0d9c2828b52)



# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
