### PR TITLE
함께 탑승하는 인원이 없을 때, 신고하기 기능 제거

### DIFF
--- a/packages/web/src/components/Chat/Header/SideMenu.tsx
+++ b/packages/web/src/components/Chat/Header/SideMenu.tsx
@@ -90,6 +90,8 @@ const SideMenu = ({ roomInfo, isOpen, setIsOpen }: SideMenuProps) => {
   const onClickCallTaxi = useCallback(() => setIsOpenCallTaxi(true), []);
   const onClickReport = useCallback(() => setIsOpenReport(true), []);
 
+  const isAlone = roomInfo.part.length === 1;
+
   const styleBackground = {
     position: "absolute" as any,
     top: 0,
@@ -192,8 +194,12 @@ const SideMenu = ({ roomInfo, isOpen, setIsOpen }: SideMenuProps) => {
           <SideMenuButton type="share" onClick={onClikcShare} />
           <DottedLine />
           <SideMenuButton type="taxi" onClick={onClickCallTaxi} />
-          <DottedLine />
-          <SideMenuButton type="report" onClick={onClickReport} />
+          {!isAlone && (
+            <>
+              <DottedLine />
+              <SideMenuButton type="report" onClick={onClickReport} />
+            </>
+          )}
         </div>
         <DottedLine />
         <div css={styleNameSection} onClick={onClickCancel}>

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -70,6 +70,7 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
   const authorName = "authorName" in chats?.[0] ? chats?.[0].authorName : "";
 
   const isBot = authorId === "bot";
+  const isAlone = roomInfo.part.length === 1;
 
   const style = {
     position: "relative" as any,
@@ -148,8 +149,11 @@ const MessageSet = ({ chats, layoutType, roomInfo }: MessageSetProps) => {
         <div css={styleProfileSection}>
           {authorId !== userOid && (
             <div
-              css={{ ...styleProfile, cursor: !isBot ? "pointer" : undefined }}
-              onClick={() => !isBot && onClickProfileImage()}
+              css={{
+                ...styleProfile,
+                cursor: !isBot && !isAlone ? "pointer" : undefined,
+              }}
+              onClick={() => !isBot && !isAlone && onClickProfileImage()}
             >
               {isBot ? (
                 <TaxiIcon css={{ width: "100%", height: "100%" }} />


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes https://github.com/sparcs-kaist/taxi-front/issues/781
함께 탑승하는 인원이 없을 때(혼자일 때), 신고하기 기능 제거
- 햄버거 메뉴의 신고하기 버튼 hide
- 프로필 이미지 클릭해도 신고하기 모달 뜨지 않음

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

![image](https://github.com/sparcs-kaist/taxi-front/assets/48019789/5392a311-c9b5-4706-b971-a9dae89c3b1c)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->
