### PR TITLE
#784 송금하지 않은 방이 있는 경우 추가 방 참여 제한

### DIFF
--- a/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyRoomSelection.tsx
@@ -110,7 +110,6 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
   const myRooms = useValueRecoilState("myRooms");
   const fetchMyRooms = useFetchRecoilState("myRooms");
   const setAlert = useSetRecoilState(alertAtom);
-  const myOngoingRoom = myRooms?.ongoing.slice() ?? []; // InfoSection의 sortedMyRoom에서 정렬만 뺐습니다.
 
   const isLogin = useIsLogin() && !!loginInfo?.id; // 로그인 여부
   const isRoomFull = roomInfo && roomInfo.part.length >= roomInfo.maxPartLength; // 방이 꽉 찼는지 여부
@@ -125,11 +124,13 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
     isLogin && myRooms && myRooms.ongoing.length >= MAX_PARTICIPATION; // 최대 참여 가능한 방 개수를 초과했는지 여부
   const isDepart = useIsTimeOver(dayServerToClient(roomInfo.time)); // 방 출발 여부
 
+  const myOngoingRoom = myRooms?.ongoing.slice() ?? []; // InfoSection의 sortedMyRoom에서 정렬만 뺐습니다.
   const notPaid = myOngoingRoom.find(
     (room) =>
-      room.part.find((item) => item._id === loginInfo?.oid).isSettlement ===
-        "send-required" && room.isDeparted
+      room.part.find((item: any) => item._id === loginInfo?.oid)
+        .isSettlement === "send-required" && room.isDeparted
   ); // 다른 사람이 정산을 올렸으나 내가 아직 송금하지 않은 방이 있는지 여부 (추가 입장 제한에 사용)
+  // item : any 가 좋은 방법인지 모르겠습니다
 
   const requestJoin = useCallback(async () => {
     if (isAlreadyPart) {
@@ -218,7 +219,7 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
         <Button
           type="purple"
           disabled={
-            notPaid || ((isRoomFull || isDepart || isMaxPart) && !isAlreadyPart)
+            (notPaid || isRoomFull || isDepart || isMaxPart) && !isAlreadyPart
           }
           css={{
             padding: "10px 0 9px",
@@ -227,10 +228,10 @@ const BodyRoomSelection = ({ roomInfo }: BodyRoomSelectionProps) => {
           }}
           onClick={requestJoin}
         >
-          {notPaid
-            ? "결제자에게 송금이 완료되지 않은 방이 있습니다."
-            : isAlreadyPart
+          {isAlreadyPart
             ? "이미 참여 중입니다 : 바로가기"
+            : notPaid
+            ? "결제자에게 송금이 완료되지 않은 방이 있습니다"
             : isDepart
             ? "출발 시각이 현재 이전인 방은 참여할 수 없습니다"
             : isRoomFull

--- a/packages/web/src/pages/Addroom/index.tsx
+++ b/packages/web/src/pages/Addroom/index.tsx
@@ -40,6 +40,7 @@ const AddRoom = () => {
   const [cookies, setCookies] = useCookies(["defaultFromTo"]);
 
   const onCall = useRef(false);
+  const loginInfo = useValueRecoilState("loginInfo");
   const today = getToday();
   const today10 = getToday10();
   const [valueName, setName] = useState("");
@@ -68,6 +69,14 @@ const AddRoom = () => {
     useState<boolean>(false);
   //#endregion
 
+  const myOngoingRoom = myRooms?.ongoing.slice() ?? []; // InfoSection의 sortedMyRoom에서 정렬만 뺐습니다.
+  const notPaid = myOngoingRoom.find(
+    (room) =>
+      room.part.find((item: any) => item._id === loginInfo?.oid)
+        .isSettlement === "send-required" && room.isDeparted
+  ); // 다른 사람이 정산을 올렸으나 내가 아직 송금하지 않은 방이 있는지 여부 (추가 입장 제한에 사용)
+  // item : any 가 좋은 방법인지 모르겠습니다
+
   useEffect(() => {
     const expirationDate = new Date();
     expirationDate.setFullYear(expirationDate.getFullYear() + 10);
@@ -91,7 +100,9 @@ const AddRoom = () => {
   }, [valueDate, valueTime]);
 
   let validatedMsg = null;
-  if (!valuePlace.every((x: Nullable<string>) => !!x)) {
+  if (notPaid) {
+    validatedMsg = "결제자에게 송금이 완료되지 않은 방이 있습니다";
+  } else if (!valuePlace.every((x: Nullable<string>) => !!x)) {
     validatedMsg = "출발지와 도착지를 선택해 주세요";
   } else if (valuePlace[0] === valuePlace[1]) {
     validatedMsg = "출발지와 도착지는 달라야 합니다";


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #784 

미정산 문제에 대한 대응 중 하나로, 다른 참여자가 정산을 올렸으나 본인이 송금하지 않은 방이 있다면 1) 추가 방 참여와 2) 새로운 방 생성을 제한합니다.

1. 방 참여
- 이미 참여 중인 방을 제외하고, 미송금 여부 확인을 최우선순위로 진행하여 송금하지 않은 방이 있다면 버튼을 비활성화하고 안내 텍스트가 보이게 합니다.

2. 방 생성
- 미송금 여부 확인을 최우선순위로 진행하여 송금하지 않은 방이 있다면 버튼을 비활성화하고 안내 텍스트가 보이게 합니다.

## 중점적으로 피드백 받고 싶은 부분

1. InfoSection에서는, 정렬된 방 목록 (`sortedMyRoom`) 에서 혹시 정산 또는 결제 (이 PR은 정산이 진행 중이나 본인이 송금하지 않은 상황에 한정되므로 조건은 다릅니다) 가 이루어지지 않은 방이 있는지를 확인하는 `notOver`라는 변수가 있습니다. 이 과정을 최대한 보존하면서 아래와 같이 수정하였는데, 관련 질문이 있습니다.
- `sortedMyRoom` 대신 정렬만 뺀 `myOngoingRoom`을 선언하여 사용했습니다. 이것이 적절한 사용인지 궁금합니다. 정렬을 하지 않을 것이라면 이렇게 선언하는 것이 불필요한 중복 변수 선언이 될 수 있는 여지가 있는지 궁금합니다.
- `notOver` 대신, 정산 진행 중이나 본인이 송금하지 않은 방이 있는지 알기 위해서, 각 방에 대하여 `part` 안에서 본인 id와 일치하면서 `isSettlement === "send-required"` 인 방을 찾아 그 여부를 `notPaid`라는 변수에 저장하는 로직이 들어가 있습니다. 방 참여 쪽 수정 사항이 들어간 `BodyRoomSelection`에는 `loginInfo`를 이미 가져오고 있어서 그대로 사용했으나, 방 생성 쪽 수정 사항이 들어간 Addroom의 index.tsx에서는 새롭게 `const loginInfo = useValueRecoilState("loginInfo");` 를 추가하였습니다. 문제가 되지 않을 것으로 판단했으나 적절한지 궁금합니다.

2. `notPaid`를 설정하는 과정에서 any type으로 인해 VSCode에서 뜨는 에러를 없애기 위해 arrow function의 매개변수를 `item: any` 라는 형식으로 썼습니다. (이것을 명시하기 전, 오류가 뜨는 상황에서도 작동은 정상적으로 되었습니다) 이것이 적절한 방법이 아닌 것 같아서, 개선할 방법이 있는지 궁금합니다.

3. 사소한 부분이나, 비활성화된 버튼의 텍스트가 적절한지 궁금합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/ad0d7487-4f1c-40e3-96ff-7afb4bd4f013)

![image](https://github.com/sparcs-kaist/taxi-front/assets/121283722/ecb5f50f-87bd-4d08-a430-7928afc6afa5)


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- room을 다루는 작업을 하면서, 주변 분들과 함께 이야기하다가 프론트와 백이 공유하는 통합된 인터페이스가 있으면 좋겠다는 의견이 나왔습니다. TS migration이나 Zod 작업에 이미 들어있는지 잘 모르겠으나, 고려하면 좋을 것 같습니다.
