### PR TITLE
#798 방 이름이 길 때 인원수 표시가 찌그러짐

### DIFF
--- a/packages/web/src/components/Room/index.jsx
+++ b/packages/web/src/components/Room/index.jsx
@@ -26,6 +26,8 @@ const Tag = (props) => {
     background:
       props.theme === "purple" ? theme.purple_hover : theme.purple_light,
     boxShadow: theme.shadow_purple_input_inset,
+    flexGrow: "0",
+    flexShrink: "0",
   };
   const paid = props.users.find((user) => user.isSettlement === "paid");
   let isDone = null;
@@ -102,6 +104,8 @@ const Room = (props) => {
   const styleName = {
     ...theme.font12,
     margin: "13px 0 12px",
+    flexShrink: "1",
+    flexGrow: "0",
   };
   const stylePlaceGrid = {
     display: "flex",


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #798 

`Room` 컴포넌트에서, 방 이름에 해당하는 스타일과 인원 수 태그에 해당하는 스타일을 고쳐서,
- 방 이름은 : flexShrink는 1로, flexGrow는 0으로
- 인원 수 태그는 : 둘 다 0으로
설정하여 태그는 원래의 크기를 항상 유지하며, 방 이름이 카드 크기나 방 이름의 길이에 맞추어 줄어들도록 하였습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/de7702b6-291b-46d0-9ce3-140d94e20110)


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

테스트를 위해 긴 이름의 방을 생성할 때, 우리가 채팅창에서 긴 채팅은 아예 입력되지 않게 한 것처럼 방 이름도 입력하는 칸에서부터 글자 수 제한을 적용하면 어떨까 합니다 (현재는 올바르지 않은 방 이름이라고 생성 버튼이 비활성화되는 방식입니다)
