### PR TITLE
[Bug] 방 이름이 너무 길면 방 이름이 X 버튼에 겹침

### DIFF
--- a/packages/web/src/components/ModalPopup/ModalRoomSelection.tsx
+++ b/packages/web/src/components/ModalPopup/ModalRoomSelection.tsx
@@ -74,7 +74,7 @@ const ModalRoomSelection = ({
 
   const styleTitle = {
     ...theme.font18,
-    padding: "10px 8px 12px",
+    padding: "10px 32px 12px 8px",
   };
 
   return (


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #801 
사진과 같이 방 이름에 해당하는 부분의 오른쪽 패딩을 X 버튼 크기만큼 더했습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/7de07ea6-fefa-4a23-a549-5e10db8c7903)


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
