### PR TITLE
[Bug] 채팅에서 메시지 전송 시 글자 수 바가 초기화되지 않는 문제 해결

### DIFF
--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -80,6 +80,7 @@ const BodyText = ({ sendMessage }: BodyTextProps) => {
       setIsSendingMessage(true);
       const result = await sendMessage("text", { text: message });
       if (!result) textareaRef.current.value = message;
+      setChatMsgLength(0);
       setIsSendingMessage(false);
     }
   };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #809 

Circular bar를 위해 길이를 저장하던 state 값을, onSend에서 0으로 만들어줘야 하는데 빠져 있었습니다. 해당 부분 수정하였습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/22ef26ab-7b71-49cf-8973-dadeac3e8518)


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
