### PR TITLE
이벤트 공유하기 기능 각종 수정 사항 구현

### DIFF
--- a/packages/web/src/components/Event/CreditAmountStatusContainer/index.tsx
+++ b/packages/web/src/components/Event/CreditAmountStatusContainer/index.tsx
@@ -9,6 +9,7 @@ import { ReactComponent as CreditIcon } from "@/static/events/2023fallCredit.svg
 import { ReactComponent as Ticket1Icon } from "@/static/events/2023fallTicket1.svg";
 // ToDo : 2023fall 이미지
 import { ReactComponent as Ticket2Icon } from "@/static/events/2023fallTicket2.svg";
+
 // ToDo : 2023fall 이미지
 
 type CreditAmountStatusContainerProps = {
@@ -34,7 +35,7 @@ const CreditAmountStatusContainer = ({
       {...whiteContainerProps}
     >
       <div css={{ color: theme.white, ...theme.font16_bold, flexGrow: 1 }}>
-        {type === "credit" ? "내가 모은 송편" : "일반 / 고급 응모권"}
+        {type === "credit" ? "내가 모은 송편코인" : "일반 / 고급 응모권"}
       </div>
       {type === "credit" ? (
         <>

--- a/packages/web/src/components/Event/WhiteContainerShareEvent/index.tsx
+++ b/packages/web/src/components/Event/WhiteContainerShareEvent/index.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { useIsLogin, useValueRecoilState } from "@/hooks/useFetchRecoilState";
+import { useAxios } from "@/hooks/useTaxiAPI";
+
+import Button from "@/components/Button";
+import {
+  ModalEvent2024FallJoin,
+  ModalEvent2024FallShare,
+  ModalNotification,
+} from "@/components/ModalPopup";
+import WhiteContainer from "@/components/WhiteContainer";
+
+import alertAtom from "@/atoms/alert";
+import { useSetRecoilState } from "recoil";
+
+import theme from "@/tools/theme";
+
+const WhiteContainerShareEvent = () => {
+  const isLogin = useIsLogin();
+  const { isAgreeOnTermsOfEvent } =
+    useValueRecoilState("event2024FallInfo") || {};
+  const [inviteUrl, setInviteUrl] = useState<string>("");
+  const [isOpenShare, setIsOpenShare] = useState<boolean>(false);
+  const axios = useAxios();
+  const setAlert = useSetRecoilState(alertAtom);
+
+  const styleText = {
+    ...theme.font14,
+    marginBottom: "12px",
+  };
+  const styleButton = {
+    padding: "14px 0 13px",
+    borderRadius: "12px",
+    ...theme.font14_bold,
+  };
+
+  const getInviteUrl = useCallback(
+    () =>
+      axios({
+        url: `/events/2024fall/invites/create`,
+        method: "post",
+        onSuccess: ({ inviteUrl }) => {
+          setInviteUrl(inviteUrl);
+        },
+        onError: () => setAlert("공유 링크를 생성하지 못했습니다."),
+      }),
+    [isAgreeOnTermsOfEvent]
+  );
+
+  useEffect(() => {
+    if (isAgreeOnTermsOfEvent) getInviteUrl();
+  }, [isAgreeOnTermsOfEvent]);
+
+  return (
+    <>
+      {isLogin && isAgreeOnTermsOfEvent && (
+        <WhiteContainer>
+          <div css={styleText}>
+            <b>🎊 이벤트 공유하기</b>
+          </div>
+          <div css={styleText}>
+            이벤트를 공유하여 친구가 이벤트에 참여하면, 친구와 함께 700
+            송편코인을 받을 수 있어요!
+          </div>
+          <Button
+            type="purple"
+            css={styleButton}
+            onClick={() => {
+              if (inviteUrl) setIsOpenShare(true);
+              else
+                setAlert(
+                  "이벤트를 공유하기 위해서는 이벤트에 참여해야 합니다."
+                );
+            }}
+          >
+            이벤트 공유하기
+          </Button>
+          <ModalEvent2024FallShare
+            isOpen={isOpenShare}
+            onChangeIsOpen={setIsOpenShare}
+            inviteUrl={inviteUrl || ""}
+          />
+        </WhiteContainer>
+      )}
+    </>
+  );
+};
+
+export default WhiteContainerShareEvent;

--- a/packages/web/src/components/Event/WhiteContainerShareEvent/index.tsx
+++ b/packages/web/src/components/Event/WhiteContainerShareEvent/index.tsx
@@ -4,11 +4,7 @@ import { useIsLogin, useValueRecoilState } from "@/hooks/useFetchRecoilState";
 import { useAxios } from "@/hooks/useTaxiAPI";
 
 import Button from "@/components/Button";
-import {
-  ModalEvent2024FallJoin,
-  ModalEvent2024FallShare,
-  ModalNotification,
-} from "@/components/ModalPopup";
+import { ModalEvent2024FallShare } from "@/components/ModalPopup";
 import WhiteContainer from "@/components/WhiteContainer";
 
 import alertAtom from "@/atoms/alert";

--- a/packages/web/src/components/Event/WhiteContainerSuggestShareEvent/index.tsx
+++ b/packages/web/src/components/Event/WhiteContainerSuggestShareEvent/index.tsx
@@ -12,7 +12,7 @@ import { useSetRecoilState } from "recoil";
 
 import theme from "@/tools/theme";
 
-const WhiteContainerShareEvent = () => {
+const WhiteContainerSuggestShareEvent = () => {
   const isLogin = useIsLogin();
   const { isAgreeOnTermsOfEvent } =
     useValueRecoilState("event2024FallInfo") || {};
@@ -83,4 +83,4 @@ const WhiteContainerShareEvent = () => {
   );
 };
 
-export default WhiteContainerShareEvent;
+export default WhiteContainerSuggestShareEvent;

--- a/packages/web/src/components/Event/WhiteContainerSuggestShareEvent/index.tsx
+++ b/packages/web/src/components/Event/WhiteContainerSuggestShareEvent/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useIsLogin, useValueRecoilState } from "@/hooks/useFetchRecoilState";
 import { useAxios } from "@/hooks/useTaxiAPI";
@@ -31,21 +31,16 @@ const WhiteContainerSuggestShareEvent = () => {
     ...theme.font14_bold,
   };
 
-  const getInviteUrl = useCallback(
-    () =>
+  useEffect(() => {
+    if (isAgreeOnTermsOfEvent)
       axios({
         url: `/events/2024fall/invites/create`,
         method: "post",
         onSuccess: ({ inviteUrl }) => {
           setInviteUrl(inviteUrl);
         },
-        onError: () => setAlert("공유 링크를 생성하지 못했습니다."),
-      }),
-    [isAgreeOnTermsOfEvent]
-  );
-
-  useEffect(() => {
-    if (isAgreeOnTermsOfEvent) getInviteUrl();
+        onError: () => setAlert("초대 링크를 생성하지 못했습니다."),
+      });
   }, [isAgreeOnTermsOfEvent]);
 
   return (
@@ -56,8 +51,8 @@ const WhiteContainerSuggestShareEvent = () => {
             <b>🎊 이벤트 공유하기</b>
           </div>
           <div css={styleText}>
-            이벤트를 공유하여 친구가 이벤트에 참여하면, 친구와 함께 700
-            송편코인을 받을 수 있어요!
+            이벤트를 공유하여 친구가 이벤트에 참여하면, 친구와 함께 송편코인
+            700개를 받을 수 있어요!
           </div>
           <Button
             type="purple"

--- a/packages/web/src/components/ModalPopup/Body/BodyEvent2024FallShare.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyEvent2024FallShare.tsx
@@ -6,6 +6,7 @@ import DottedLine from "@/components/DottedLine";
 import LinkCopy from "@/components/Link/LinkCopy";
 import LinkKakaotalkShare from "@/components/Link/LinkKakaotalkShare";
 
+import { ogServer } from "@/tools/loadenv";
 import theme from "@/tools/theme";
 
 import { ReactComponent as KakaoTalkLogo } from "@/static/assets/serviceLogos/KakaoTalkLogo.svg";
@@ -21,8 +22,6 @@ const BodyEvent2024FallShare = ({
   height,
   inviteUrl,
 }: BodyEvent2024FallShareProps) => {
-  const { origin } = window.location;
-
   const [isCopied, setIsCopied] = useState(false);
   const onCopy = useCallback(() => setIsCopied(true), [setIsCopied]);
 
@@ -62,9 +61,9 @@ const BodyEvent2024FallShare = ({
   return (
     <div css={styleWrapper}>
       <div css={styleGuide}>
-        이벤트를 여러 사람들에게 공유할 수 있습니다. 이 링크를 통해 다른
+        이벤트를 다른 사람들에게 공유할 수 있습니다. 이 링크를 통해 다른
         사용자가 이벤트에 참여하면, 회원님과 새 참여자 모두{" "}
-        <b>700 송편코인을 획득</b>합니다.
+        <b>송편코인 700개</b>를 획득합니다.
       </div>
       <DottedLine />
       <div css={{ flexGrow: 1 }} />
@@ -75,10 +74,12 @@ const BodyEvent2024FallShare = ({
       <div css={styleButtonSection}>
         <LinkKakaotalkShare
           title={"Taxi 추석 이벤트"}
-          description={`Taxi 추석 이벤트에 참여해보세요! 이 링크로 참여하면 700 송편코인을 획득할 수 있어요!`}
+          description={`Taxi 추석 이벤트에 참여해 보세요! 이 링크로 참여하면 송편코인 700개를 획득할 수 있어요!`}
           imageUrl={
-            origin + "/2024springEvent-graph.png"
-          } /* ToDo : OG Image 연결 */
+            ogServer
+              ? `${ogServer}/eventInvite/${inviteUrl.split("/").pop()}`
+              : undefined
+          }
           buttonText="확인하기"
           buttonTo={new URL(inviteUrl).pathname}
           partNum={1}
@@ -90,7 +91,7 @@ const BodyEvent2024FallShare = ({
           />
         </LinkKakaotalkShare>
         <LinkCopy
-          value={`Taxi 추석 이벤트에 참여하세요!\n🚕 참여 링크: ${inviteUrl}`}
+          value={`🚕 Taxi 추석 이벤트에 참여해 보세요!\n🚕 참여 링크: ${inviteUrl}`}
           onCopy={onCopy}
         >
           <ButtonShare

--- a/packages/web/src/components/ModalPopup/Body/BodyEvent2024FallShare.tsx
+++ b/packages/web/src/components/ModalPopup/Body/BodyEvent2024FallShare.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from "react";
+import QRCode from "react-qr-code";
+
+import ButtonShare from "@/components/Button/ButtonShare";
+import DottedLine from "@/components/DottedLine";
+import LinkCopy from "@/components/Link/LinkCopy";
+import LinkKakaotalkShare from "@/components/Link/LinkKakaotalkShare";
+
+import theme from "@/tools/theme";
+
+import { ReactComponent as KakaoTalkLogo } from "@/static/assets/serviceLogos/KakaoTalkLogo.svg";
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
+export type BodyEvent2024FallShareProps = {
+  inviteUrl: string;
+  height?: number;
+};
+
+const BodyEvent2024FallShare = ({
+  height,
+  inviteUrl,
+}: BodyEvent2024FallShareProps) => {
+  const { origin } = window.location;
+
+  const [isCopied, setIsCopied] = useState(false);
+  const onCopy = useCallback(() => setIsCopied(true), [setIsCopied]);
+
+  useEffect(() => {
+    if (isCopied) {
+      const timer = setTimeout(() => setIsCopied(false), 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [isCopied]);
+
+  const styleWrapper = height
+    ? {
+        height,
+        display: "flex",
+        flexDirection: "column" as any,
+      }
+    : {};
+
+  const styleGuide = {
+    ...theme.font12,
+    color: theme.gray_text,
+    margin: "0 8px 12px",
+  };
+  const styleQRSection = {
+    marginTop: "12px",
+    position: "relative" as any,
+    overflow: "hidden",
+    textAlign: "center" as any,
+  };
+  const styleButtonSection = {
+    display: "flex",
+    justifyContent: "center",
+    gap: "10px",
+    margin: "12px 0px 0",
+  };
+
+  return (
+    <div css={styleWrapper}>
+      <div css={styleGuide}>
+        이벤트를 여러 사람들에게 공유할 수 있습니다. 이 링크를 통해 다른
+        사용자가 이벤트에 참여하면, 회원님과 새 참여자 모두{" "}
+        <b>700 송편코인을 획득</b>합니다.
+      </div>
+      <DottedLine />
+      <div css={{ flexGrow: 1 }} />
+      <div css={styleQRSection}>
+        <QRCode value={inviteUrl} size={120} bgColor="none" />
+      </div>
+      <div css={{ flexGrow: 1 }} />
+      <div css={styleButtonSection}>
+        <LinkKakaotalkShare
+          title={"Taxi 추석 이벤트"}
+          description={`Taxi 추석 이벤트에 참여해보세요! 이 링크로 참여하면 700 송편코인을 획득할 수 있어요!`}
+          imageUrl={
+            origin + "/2024springEvent-graph.png"
+          } /* ToDo : OG Image 연결 */
+          buttonText="확인하기"
+          buttonTo={new URL(inviteUrl).pathname}
+          partNum={1}
+        >
+          <ButtonShare
+            text="카카오톡"
+            icon={<KakaoTalkLogo css={{ width: "22px" }} />}
+            background="#FFE812"
+          />
+        </LinkKakaotalkShare>
+        <LinkCopy
+          value={`Taxi 추석 이벤트에 참여하세요!\n🚕 참여 링크: ${inviteUrl}`}
+          onCopy={onCopy}
+        >
+          <ButtonShare
+            text="초대 복사"
+            icon={
+              isCopied ? (
+                <CheckIcon style={{ fontSize: "16px" }} />
+              ) : (
+                <ContentCopyIcon style={{ fontSize: "16px" }} />
+              )
+            }
+            background={theme.gray_background}
+          />
+        </LinkCopy>
+      </div>
+    </div>
+  );
+};
+
+export default BodyEvent2024FallShare;

--- a/packages/web/src/components/ModalPopup/ModalEvent2024FallJoin.tsx
+++ b/packages/web/src/components/ModalPopup/ModalEvent2024FallJoin.tsx
@@ -114,7 +114,7 @@ const ModalEvent2024FallJoin = ({
     <Modal padding="16px 12px 12px" {...modalProps}>
       <div css={styleTitle}>
         <FestivalRoundedIcon style={styleIcon} />
-        2024 추석 이벤트 이름 지어줘
+        Taxi 추석 이벤트
       </div>
       <div css={styleText}>
         • 택시 동승을 하지 않는 사용자는{" "}
@@ -163,8 +163,8 @@ const ModalEvent2024FallJoin = ({
       </div>
       <div css={{ height: "12px" }} />
       <div css={styleText}>
-        • 본 약관은 동의 이후에도 {'"'}마이페이지{">"}한가위 송편 이벤트 참여
-        약관{'"'}에서 다시 확인하실 수 있습니다.{" "}
+        • 본 약관은 동의 이후에도 {'"'}마이페이지{">"}추석 이벤트 참여 약관{'"'}
+        에서 다시 확인하실 수 있습니다.{" "}
       </div>
       {isLogin &&
         (isAgreeOnTermsOfEvent ? (

--- a/packages/web/src/components/ModalPopup/ModalEvent2024FallJoin.tsx
+++ b/packages/web/src/components/ModalPopup/ModalEvent2024FallJoin.tsx
@@ -13,6 +13,7 @@ import DottedLine from "@/components/DottedLine";
 import Input from "@/components/Input";
 import Modal from "@/components/Modal";
 
+import LinkLogin from "../Link/LinkLogin";
 import ProfileImage from "../User/ProfileImage";
 
 import alertAtom from "@/atoms/alert";
@@ -108,7 +109,7 @@ const ModalEvent2024FallJoin = ({
     margin: "0 8px",
   };
   const styleInputWrap = {
-    margin: "12px 8px",
+    margin: "0 8px 12px",
     display: "flex",
     alignItems: "center",
     color: theme.gray_text,
@@ -116,7 +117,6 @@ const ModalEvent2024FallJoin = ({
     ...theme.font14,
   } as const;
 
-  // ToDo : 글 작성
   return (
     <Modal padding="16px 12px 12px" {...modalProps}>
       <div css={styleTitle}>
@@ -144,18 +144,18 @@ const ModalEvent2024FallJoin = ({
         위 경우, SPARCS Taxi팀 서비스 관리자는 서비스 부정 이용을 방지하기 위해
         택시 탑승을 인증할 수 있는{" "}
         <b css={{ color: theme.black }}>영수증 또는 카카오T 이용기록</b>을
-        요청할 수 있습니다. 또한, 본 서비스를 부정 이용하는 사용자에게는 택시
+        요청할 수 있습니다. 또한, 본 서비스를 부정 이용하는 사용자에게는 Taxi
         서비스 이용 제한 및 법적 조치를 취할 수 있습니다.
       </div>
       <div css={{ height: "12px" }} />
       <div css={styleText}>
         •{" "}
         <b css={{ color: theme.red_text }}>
-          입력해주신 연락처로 이벤트 상품을 전달해드립니다.
+          입력하신 연락처로 이벤트 상품을 전달해 드립니다.
         </b>{" "}
         또한, 서비스 신고 대응 및 본인 확인을 위해 사용될 수 있습니다.{" "}
         <b css={{ color: theme.red_text }}>
-          입력해주신 연락처는 이후 수정이 불가능합니다.
+          입력하신 연락처는 이후 수정이 불가능합니다.
         </b>
       </div>
       <div css={{ height: "12px" }} />
@@ -165,19 +165,20 @@ const ModalEvent2024FallJoin = ({
           추천인 이벤트 참여를 위해서는 추천인이 발송한 링크로 이벤트에 참여해야
           합니다.
         </b>{" "}
-        추천인을 통해 이벤트에 참여할 시, 참가자와 추천인 모두에게 700
-        송편코인이 지급됩니다.
+        추천인을 통해 이벤트에 참여할 시, 참가자와 추천인 모두에게 송편코인
+        700개가 지급됩니다.
       </div>
       <div css={{ height: "12px" }} />
       <div css={styleText}>
         • 본 약관은 동의 이후에도 {'"'}마이페이지{">"}추석 이벤트 참여 약관{'"'}
         에서 다시 확인하실 수 있습니다.{" "}
       </div>
-      {isLogin &&
-        (isAgreeOnTermsOfEvent ? (
+      <div css={{ height: "12px" }} />
+      <DottedLine />
+      <div css={{ height: "12px" }} />
+      {isLogin ? (
+        isAgreeOnTermsOfEvent ? (
           <>
-            <div css={{ height: "12px" }} />
-            <DottedLine />
             <div css={styleInputWrap}>
               전화번호
               <Input
@@ -200,8 +201,6 @@ const ModalEvent2024FallJoin = ({
           </>
         ) : (
           <>
-            <div css={{ height: "12px" }} />
-            <DottedLine />
             <div css={styleInputWrap}>
               전화번호
               <Input
@@ -211,6 +210,27 @@ const ModalEvent2024FallJoin = ({
                 css={{ width: "100%", marginLeft: "10px" }}
               />
             </div>
+            {isInvited && inviterInfo && (
+              <div css={styleInputWrap}>
+                추천인
+                <div
+                  css={{
+                    width: "24px",
+                    height: "24px",
+                    margin: "0px 10px",
+                    borderRadius: "12px",
+                    overflow: "hidden",
+                    boxShadow: theme.shadow,
+                    flexShrink: 0,
+                  }}
+                >
+                  <ProfileImage url={inviterInfo?.profileImageUrl} />
+                </div>
+                <span css={{ width: "100%", ...theme.ellipsis }}>
+                  {inviterInfo?.nickname}
+                </span>
+              </div>
+            )}
             <Button
               type="purple_inset"
               css={{
@@ -227,27 +247,21 @@ const ModalEvent2024FallJoin = ({
                 : "동의 후 이벤트 참여하기"}
             </Button>
           </>
-        ))}
-      {isInvited && inviterInfo && (
-        <div css={styleInputWrap}>
-          추천인
-          <div
+        )
+      ) : (
+        <LinkLogin>
+          <Button
+            type="purple_inset"
             css={{
-              width: "24px",
-              height: "24px",
-              margin: "0px 10px",
-              borderRadius: "12px",
-              overflow: "hidden",
-              boxShadow: theme.shadow,
-              flexShrink: 0,
+              width: "100%",
+              padding: "10px 0 9px",
+              borderRadius: "8px",
+              ...theme.font14_bold,
             }}
           >
-            <ProfileImage url={inviterInfo?.profileImageUrl} />
-          </div>
-          <span css={{ width: "100%", ...theme.ellipsis }}>
-            {inviterInfo?.nickname}
-          </span>
-        </div>
+            로그인 후 이벤트 참여하기
+          </Button>
+        </LinkLogin>
       )}
     </Modal>
   );

--- a/packages/web/src/components/ModalPopup/ModalEvent2024FallJoin.tsx
+++ b/packages/web/src/components/ModalPopup/ModalEvent2024FallJoin.tsx
@@ -25,6 +25,7 @@ import FestivalRoundedIcon from "@mui/icons-material/FestivalRounded";
 
 type ModalEvent2024FallJoinProps = Parameters<typeof Modal>[0] & {
   inviterId?: string;
+  defaultPhoneNumber?: string;
 };
 
 const ModalEvent2024FallJoin = ({
@@ -43,7 +44,9 @@ const ModalEvent2024FallJoin = ({
   const event2024FallQuestComplete = useEvent2024FallQuestComplete();
   //#endregion
 
-  const [phoneNumber, setPhoneNumber] = useState<string>("");
+  const [phoneNumber, setPhoneNumber] = useState<string>(
+    phoneNumberFromLoginInfo || ""
+  );
   const isValidPhoneNumber = useMemo(
     () => regExpTest.phoneNumber(phoneNumber),
     [phoneNumber]
@@ -54,6 +57,10 @@ const ModalEvent2024FallJoin = ({
     nickname: string;
   }>();
   const isInvited = !!inviterId;
+
+  useEffect(() => {
+    setPhoneNumber(phoneNumberFromLoginInfo || "");
+  }, [modalProps.isOpen]);
 
   useEffect(() => {
     if (isAgreeOnTermsOfEvent || !isInvited) return;

--- a/packages/web/src/components/ModalPopup/ModalEvent2024FallShare.tsx
+++ b/packages/web/src/components/ModalPopup/ModalEvent2024FallShare.tsx
@@ -1,0 +1,49 @@
+import Modal from "@/components/Modal";
+
+import BodyEvent2024FallShare, {
+  BodyEvent2024FallShareProps,
+} from "./Body/BodyEvent2024FallShare";
+
+import theme from "@/tools/theme";
+
+import ShareRoundedIcon from "@mui/icons-material/ShareRounded";
+
+type ModalEvent2024FallShareProps = {
+  isOpen: boolean;
+  onChangeIsOpen?: (isOpen: boolean) => void;
+  inviteUrl: BodyEvent2024FallShareProps["inviteUrl"];
+};
+
+const ModalEvent2024FallShare = ({
+  isOpen,
+  onChangeIsOpen,
+  inviteUrl,
+}: ModalEvent2024FallShareProps) => {
+  const styleTitle = {
+    ...theme.font18,
+    display: "flex",
+    alignItems: "center",
+    margin: "0 8px 12px",
+  };
+  const styleIcon = {
+    fontSize: "21px",
+    margin: "0 4px 0 0",
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onChangeIsOpen={onChangeIsOpen}
+      padding="16px 12px 12px"
+    >
+      <div css={styleTitle}>
+        <ShareRoundedIcon style={styleIcon} />
+        이벤트 공유하기
+      </div>
+      <BodyEvent2024FallShare inviteUrl={inviteUrl} />
+    </Modal>
+  );
+};
+
+export default ModalEvent2024FallShare;
+export { BodyEvent2024FallShare };

--- a/packages/web/src/components/ModalPopup/index.tsx
+++ b/packages/web/src/components/ModalPopup/index.tsx
@@ -15,6 +15,7 @@ export { default as ModalEvent2024SpringShare } from "./ModalEvent2024SpringShar
 export { default as ModalEvent2024FallItem } from "./ModalEvent2024FallItem";
 export { default as ModalEvent2024FallJoin } from "./ModalEvent2024FallJoin";
 export { default as ModalEvent2024FallRandomBox } from "./ModalEvent2024FallRandomBox";
+export { default as ModalEvent2024FallShare } from "./ModalEvent2024FallShare";
 
 export { default as ModalMypageModify } from "./ModalMypageModify";
 export { default as ModalNotification } from "./ModalNotification";

--- a/packages/web/src/pages/Event/Event2024Fall.tsx
+++ b/packages/web/src/pages/Event/Event2024Fall.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 
 import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 import { useAxios } from "@/hooks/useTaxiAPI";
@@ -36,21 +36,16 @@ const Event2024Fall = () => {
     useValueRecoilState("event2024FallInfo") || {};
   const axios = useAxios();
 
-  const getInviteUrl = useCallback(
-    () =>
+  useEffect(() => {
+    if (isAgreeOnTermsOfEvent)
       axios({
         url: `/events/2024fall/invites/create`,
         method: "post",
         onSuccess: ({ inviteUrl }) => {
           setInviteUrl(inviteUrl);
         },
-        onError: () => setAlert("공유 링크를 생성하지 못했습니다."),
-      }),
-    [isAgreeOnTermsOfEvent]
-  );
-
-  useEffect(() => {
-    if (isAgreeOnTermsOfEvent) getInviteUrl();
+        onError: () => setAlert("초대 링크를 생성하지 못했습니다."),
+      });
   }, [isAgreeOnTermsOfEvent]);
 
   return (
@@ -271,7 +266,7 @@ const Event2024Fall = () => {
                 color: theme.gray_text,
               }}
             >
-              나의 링크로 친구가 이벤트에 참여하면
+              나의 초대 링크로 친구가 이벤트에 참여하면
               <br />
               친구와 나 모두 송편코인 700개 획득!
             </div>

--- a/packages/web/src/pages/Event/Event2024Fall.tsx
+++ b/packages/web/src/pages/Event/Event2024Fall.tsx
@@ -1,10 +1,17 @@
-import { memo } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
+
+import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
+import { useAxios } from "@/hooks/useTaxiAPI";
 
 import AdaptiveDiv from "@/components/AdaptiveDiv";
 import Button from "@/components/Button";
 import Footer from "@/components/Footer";
 import HeaderWithBackButton from "@/components/Header/HeaderWithBackButton";
+import { ModalEvent2024FallShare } from "@/components/ModalPopup";
 import WhiteContainer from "@/components/WhiteContainer";
+
+import alertAtom from "@/atoms/alert";
+import { useSetRecoilState } from "recoil";
 
 import theme from "@/tools/theme";
 
@@ -21,240 +28,327 @@ import { ReactComponent as MainTitle } from "@/static/events/2024fallMainTitle.s
 const EVENT_INSTAGRAM_URL =
   "https://www.instagram.com/p/C_H7YTfPEGZ/?igsh=MXh3MWc0NnJsZml3MQ==";
 
-const Event2024Fall = () => (
-  <>
-    <HeaderWithBackButton>
-      <div css={{ color: theme.purple, ...theme.font18 }}>이벤트 안내</div>
-    </HeaderWithBackButton>
-    <AdaptiveDiv
-      type="center"
-      css={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-      }}
-    >
-      <TaxiLogoIcon
-        css={{ width: "71.36px", maxWidth: "100%", marginTop: "20px" }}
+const Event2024Fall = () => {
+  const [isOpenShare, setIsOpenShare] = useState<boolean>(false);
+  const [inviteUrl, setInviteUrl] = useState<string>("");
+  const setAlert = useSetRecoilState(alertAtom);
+  const { isAgreeOnTermsOfEvent } =
+    useValueRecoilState("event2024FallInfo") || {};
+  const axios = useAxios();
+
+  const getInviteUrl = useCallback(
+    () =>
+      axios({
+        url: `/events/2024fall/invites/create`,
+        method: "post",
+        onSuccess: ({ inviteUrl }) => {
+          setInviteUrl(inviteUrl);
+        },
+        onError: () => setAlert("공유 링크를 생성하지 못했습니다."),
+      }),
+    [isAgreeOnTermsOfEvent]
+  );
+
+  useEffect(() => {
+    if (isAgreeOnTermsOfEvent) getInviteUrl();
+  }, [isAgreeOnTermsOfEvent]);
+
+  return (
+    <>
+      <HeaderWithBackButton>
+        <div css={{ color: theme.purple, ...theme.font18 }}>이벤트 안내</div>
+      </HeaderWithBackButton>
+      <ModalEvent2024FallShare
+        isOpen={isOpenShare}
+        onChangeIsOpen={setIsOpenShare}
+        inviteUrl={inviteUrl || ""}
       />
-      <MainTitle
-        css={{ width: "218px", maxWidth: "100%", marginTop: "12px" }}
-      />
-      <div
-        css={{ ...theme.font16_bold, color: theme.purple, marginTop: "16px" }}
+      <AdaptiveDiv
+        type="center"
+        css={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
       >
-        2024.9.7.(토) ~ 9.23.(월)
-      </div>
-      <MainSection1 css={{ width: "100%" }} />
-    </AdaptiveDiv>
-    <div css={{ background: theme.purple, height: "253px" }}>
-      <AdaptiveDiv type="center">
-        <MainSection2 css={{ width: "100%" }} />
+        <TaxiLogoIcon
+          css={{ width: "71.36px", maxWidth: "100%", marginTop: "20px" }}
+        />
+        <MainTitle
+          css={{ width: "218px", maxWidth: "100%", marginTop: "12px" }}
+        />
+        <div
+          css={{ ...theme.font16_bold, color: theme.purple, marginTop: "16px" }}
+        >
+          2024.9.7.(토) ~ 9.23.(월)
+        </div>
+        <MainSection1 css={{ width: "100%" }} />
       </AdaptiveDiv>
-    </div>
-    <div css={{ background: theme.purple_disabled, padding: "20px 0" }}>
-      <AdaptiveDiv type="center">
-        <WhiteContainer
-          css={{ margin: 0, padding: "16px", textAlign: "center" }}
-        >
-          <div
-            css={{
-              ...theme.font14_bold,
-              color: theme.purple,
-            }}
+      <div css={{ background: theme.purple, height: "253px" }}>
+        <AdaptiveDiv type="center">
+          <MainSection2 css={{ width: "100%" }} />
+        </AdaptiveDiv>
+      </div>
+      <div css={{ background: theme.purple_disabled, padding: "20px 0" }}>
+        <AdaptiveDiv type="center">
+          <WhiteContainer
+            css={{ margin: 0, padding: "16px", textAlign: "center" }}
           >
-            STEP 1
-          </div>
+            <div
+              css={{
+                ...theme.font14_bold,
+                color: theme.purple,
+              }}
+            >
+              STEP 1
+            </div>
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font20,
+                color: theme.black,
+              }}
+            >
+              Taxi 퀘스트 달성하고
+              <br />
+              송편코인을 모아보세요!
+            </div>
+            <div css={{ height: "16px" }} />
+            <MissionCompleteIcon css={{ width: "192px", maxWidth: "100%" }} />
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font14,
+                color: theme.gray_text,
+              }}
+            >
+              Taxi 웹 사이트와 앱에서 퀘스트 내용 확인
+              <br />
+              이벤트 참여 동의만 해도 송편코인 200개 지급
+            </div>
+            <div css={{ height: "16px" }} />
+            {/* <Link to="/event/2024fall-missions" css={{ textDecoration: "none" }}> */}
+            <Button
+              disabled
+              type="purple_inset"
+              css={{
+                padding: "14px 0 13px",
+                borderRadius: "12px",
+                ...theme.font14_bold,
+              }}
+            >
+              이벤트 시작 후 확인해 보세요!
+            </Button>
+            {/* </Link> */}
+          </WhiteContainer>
           <div css={{ height: "16px" }} />
-          <div
-            css={{
-              ...theme.font20,
-              color: theme.black,
-            }}
+          <WhiteContainer
+            css={{ margin: 0, padding: "16px", textAlign: "center" }}
           >
-            Taxi 퀘스트 달성하고
-            <br />
-            송편코인을 모아보세요!
-          </div>
+            <div
+              css={{
+                ...theme.font14_bold,
+                color: theme.purple,
+              }}
+            >
+              STEP 2
+            </div>
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font20,
+                color: theme.black,
+              }}
+            >
+              응모권 교환소에서
+              <br />
+              경품 응모권을 구매해 보세요!
+            </div>
+            <div css={{ height: "16px" }} />
+            <MainStep2 css={{ width: "100%" }} />
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font14,
+                color: theme.gray_text,
+              }}
+            >
+              응모권은 경품마다 별개로 발급됨
+              <br />
+              경품 추첨 결과는 9월 30일에 발표
+            </div>
+            <div css={{ height: "16px" }} />
+            {/* <Link to="/event/2024fall-store" css={{ textDecoration: "none" }}> */}
+            <Button
+              disabled
+              type="purple_inset"
+              css={{
+                padding: "14px 0 13px",
+                borderRadius: "12px",
+                ...theme.font14_bold,
+              }}
+            >
+              이벤트 시작 후 확인해 보세요!
+            </Button>
+            {/* </Link> */}
+          </WhiteContainer>
           <div css={{ height: "16px" }} />
-          <MissionCompleteIcon css={{ width: "192px", maxWidth: "100%" }} />
-          <div css={{ height: "16px" }} />
-          <div
-            css={{
-              ...theme.font14,
-              color: theme.gray_text,
-            }}
+          <WhiteContainer
+            css={{ margin: 0, padding: "16px", textAlign: "center" }}
           >
-            Taxi 웹 사이트와 앱에서 퀘스트 내용 확인
-            <br />
-            이벤트 참여 동의만 해도 송편코인 200개 지급
-          </div>
-          <div css={{ height: "16px" }} />
-          {/* <Link to="/event/2024fall-missions" css={{ textDecoration: "none" }}> */}
-          <Button
-            disabled
-            type="purple_inset"
-            css={{
-              padding: "14px 0 13px",
-              borderRadius: "12px",
-              ...theme.font14_bold,
-            }}
-          >
-            이벤트 시작 후 확인해 보세요!
-          </Button>
-          {/* </Link> */}
-        </WhiteContainer>
-        <div css={{ height: "16px" }} />
-        <WhiteContainer
-          css={{ margin: 0, padding: "16px", textAlign: "center" }}
-        >
-          <div
-            css={{
-              ...theme.font14_bold,
-              color: theme.purple,
-            }}
-          >
-            STEP 2
-          </div>
-          <div css={{ height: "16px" }} />
-          <div
-            css={{
-              ...theme.font20,
-              color: theme.black,
-            }}
-          >
-            응모권 교환소에서
-            <br />
-            경품 응모권을 구매해 보세요!
-          </div>
-          <div css={{ height: "16px" }} />
-          <MainStep2 css={{ width: "100%" }} />
-          <div css={{ height: "16px" }} />
-          <div
-            css={{
-              ...theme.font14,
-              color: theme.gray_text,
-            }}
-          >
-            응모권은 경품마다 별개로 발급됨
-            <br />
-            경품 추첨 결과는 9월 30일에 발표
-          </div>
-          <div css={{ height: "16px" }} />
-          {/* <Link to="/event/2024fall-store" css={{ textDecoration: "none" }}> */}
-          <Button
-            disabled
-            type="purple_inset"
-            css={{
-              padding: "14px 0 13px",
-              borderRadius: "12px",
-              ...theme.font14_bold,
-            }}
-          >
-            이벤트 시작 후 확인해 보세요!
-          </Button>
-          {/* </Link> */}
-        </WhiteContainer>
-        <div css={{ height: "16px" }} />
-        <WhiteContainer
-          css={{ margin: 0, padding: "16px", textAlign: "center" }}
-        >
-          <div
-            css={{
-              ...theme.font14_bold,
-              color: theme.purple,
-            }}
-          >
-            STEP 3
-          </div>
-          <div css={{ height: "16px" }} />
-          <div
-            css={{
-              ...theme.font20,
-              color: theme.black,
-            }}
-          >
-            경품 당첨 확률
-            <br />
-            리더보드를 확인하세요!
-          </div>
-          <div css={{ height: "16px" }} />
-          <MainStep3 css={{ width: "233px", maxWidth: "100%" }} />
-          <div css={{ height: "16px" }} />
-          <div
-            css={{
-              ...theme.font14,
-              color: theme.gray_text,
-            }}
-          >
-            응모권 개수가 많을수록 당첨 확률이 상승함
-            <br />위 이미지는 실제와 다를 수 있음
-          </div>
-          <div css={{ height: "16px" }} />
-          {/* <Link
+            <div
+              css={{
+                ...theme.font14_bold,
+                color: theme.purple,
+              }}
+            >
+              STEP 3
+            </div>
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font20,
+                color: theme.black,
+              }}
+            >
+              경품 당첨 확률
+              <br />
+              리더보드를 확인하세요!
+            </div>
+            <div css={{ height: "16px" }} />
+            <MainStep3 css={{ width: "233px", maxWidth: "100%" }} />
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font14,
+                color: theme.gray_text,
+              }}
+            >
+              응모권 개수가 많을수록 당첨 확률이 상승함
+              <br />위 이미지는 실제와 다를 수 있음
+            </div>
+            <div css={{ height: "16px" }} />
+            {/* <Link
             to="/event/2024fall-leaderboard"
             css={{ textDecoration: "none" }}
           > */}
-          <Button
-            disabled
-            type="purple_inset"
-            css={{
-              padding: "14px 0 13px",
-              borderRadius: "12px",
-              ...theme.font14_bold,
-            }}
+            <Button
+              disabled
+              type="purple_inset"
+              css={{
+                padding: "14px 0 13px",
+                borderRadius: "12px",
+                ...theme.font14_bold,
+              }}
+            >
+              {/* 응모권 순위 확인하기 */}
+              이벤트 시작 후 확인해 보세요!
+            </Button>
+            {/* </Link> */}
+          </WhiteContainer>
+          <div css={{ height: "16px" }} />
+          <WhiteContainer
+            css={{ margin: 0, padding: "16px", textAlign: "center" }}
           >
-            {/* 응모권 순위 확인하기 */}
-            이벤트 시작 후 확인해 보세요!
-          </Button>
-          {/* </Link> */}
-        </WhiteContainer>
-      </AdaptiveDiv>
-    </div>
-    <div
-      css={{
-        background: "linear-gradient(to top, #797F6C, #203F76)",
-        pointerEvents: "none",
-        ...theme.cursor(),
-      }}
-      onClick={() => window.open(EVENT_INSTAGRAM_URL, "_blank")}
-    >
-      <AdaptiveDiv type="center" css={{ padding: "16px", textAlign: "center" }}>
-        <div css={{ color: theme.white, ...theme.font14_bold }}>EVENT</div>
-        <div css={{ height: "16px" }} />
-        <div css={{ color: theme.white, ...theme.font20 }}>
-          인스타그램 스토리 공유하고
-          <br />
-          공유 이벤트에 참여하세요!
-        </div>
-        <div css={{ height: "16px" }} />
-        <MainSection4 css={{ width: "334px", maxWidth: "100%" }} />
-        <div css={{ height: "16px" }} />
-        <div css={{ color: theme.gray_line, ...theme.font14 }}>
-          {/* 추첨 결과는 인스타그램, Ara, Taxi 홈페이지에 발표
+            <div
+              css={{
+                ...theme.font14_bold,
+                color: theme.purple,
+              }}
+            >
+              BONUS
+            </div>
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font20,
+                color: theme.black,
+              }}
+            >
+              이벤트를 친구에게 공유하고
+              <br />
+              친구와 함께 송편코인 받아가세요!
+            </div>
+            <div css={{ height: "16px" }} />
+            <div
+              css={{
+                ...theme.font14,
+                color: theme.gray_text,
+              }}
+            >
+              나의 링크로 친구가 이벤트에 참여하면
+              <br />
+              친구와 나 모두 송편코인 700개 획득!
+            </div>
+            <div css={{ height: "16px" }} />
+            <Button
+              type="purple_inset"
+              css={{
+                padding: "14px 0 13px",
+                borderRadius: "12px",
+                ...theme.font14_bold,
+              }}
+              onClick={() => {
+                if (inviteUrl) setIsOpenShare(true);
+                else
+                  setAlert(
+                    "이벤트를 공유하기 위해서는 이벤트에 참여해야 합니다."
+                  );
+              }}
+            >
+              이벤트 공유하기
+            </Button>
+          </WhiteContainer>
+        </AdaptiveDiv>
+      </div>
+      <div
+        css={{
+          background: "linear-gradient(to top, #797F6C, #203F76)",
+          pointerEvents: "none",
+          ...theme.cursor(),
+        }}
+        onClick={() => window.open(EVENT_INSTAGRAM_URL, "_blank")}
+      >
+        <AdaptiveDiv
+          type="center"
+          css={{ padding: "16px", textAlign: "center" }}
+        >
+          <div css={{ color: theme.white, ...theme.font14_bold }}>EVENT</div>
+          <div css={{ height: "16px" }} />
+          <div css={{ color: theme.white, ...theme.font20 }}>
+            인스타그램 스토리 공유하고
+            <br />
+            공유 이벤트에 참여하세요!
+          </div>
+          <div css={{ height: "16px" }} />
+          <MainSection4 css={{ width: "334px", maxWidth: "100%" }} />
+          <div css={{ height: "16px" }} />
+          <div css={{ color: theme.gray_line, ...theme.font14 }}>
+            {/* 추첨 결과는 인스타그램, Ara, Taxi 홈페이지에 발표
           <br />
           실물 상품 또는 기프티콘으로 지급
           <br /> */}
-          인스타그램 게시물은 9월 6일 정오에 업로드 예정
-        </div>
-      </AdaptiveDiv>
-    </div>
-    <div
-      css={{
-        padding: "56px 0 16px",
-        background: theme.white,
-      }}
-    >
-      <AdaptiveDiv type="center" css={{ textAlign: "center" }}>
-        <MainSection6 css={{ width: "292px", maxWidth: "100%" }} />
-        <div css={{ height: "56px" }} />
-        <div css={{ color: theme.gray_text, ...theme.font14 }}>
-          본 이벤트는 현대모비스와 에이핀아이앤씨의 후원으로 진행되었습니다.
-        </div>
-      </AdaptiveDiv>
-    </div>
-    <Footer type="event-2024fall" />
-  </>
-);
+            인스타그램 게시물은 9월 6일 정오에 업로드 예정
+          </div>
+        </AdaptiveDiv>
+      </div>
+      <div
+        css={{
+          padding: "56px 0 16px",
+          background: theme.white,
+        }}
+      >
+        <AdaptiveDiv type="center" css={{ textAlign: "center" }}>
+          <MainSection6 css={{ width: "292px", maxWidth: "100%" }} />
+          <div css={{ height: "56px" }} />
+          <div css={{ color: theme.gray_text, ...theme.font14 }}>
+            본 이벤트는 현대모비스와 에이핀아이앤씨의 후원으로 진행되었습니다.
+          </div>
+        </AdaptiveDiv>
+      </div>
+      <Footer type="event-2024fall" />
+    </>
+  );
+};
 
 export default memo(Event2024Fall);

--- a/packages/web/src/pages/Event/Event2024Fall.tsx
+++ b/packages/web/src/pages/Event/Event2024Fall.tsx
@@ -58,11 +58,6 @@ const Event2024Fall = () => {
       <HeaderWithBackButton>
         <div css={{ color: theme.purple, ...theme.font18 }}>이벤트 안내</div>
       </HeaderWithBackButton>
-      <ModalEvent2024FallShare
-        isOpen={isOpenShare}
-        onChangeIsOpen={setIsOpenShare}
-        inviteUrl={inviteUrl || ""}
-      />
       <AdaptiveDiv
         type="center"
         css={{
@@ -299,6 +294,11 @@ const Event2024Fall = () => {
               이벤트 공유하기
             </Button>
           </WhiteContainer>
+          <ModalEvent2024FallShare
+            isOpen={isOpenShare}
+            onChangeIsOpen={setIsOpenShare}
+            inviteUrl={inviteUrl || ""}
+          />
         </AdaptiveDiv>
       </div>
       <div

--- a/packages/web/src/pages/Event/Event2024FallMissions.tsx
+++ b/packages/web/src/pages/Event/Event2024FallMissions.tsx
@@ -6,8 +6,8 @@ import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 
 import AdaptiveDiv from "@/components/AdaptiveDiv";
 import CreditAmountStatusContainer from "@/components/Event/CreditAmountStatusContainer";
-import WhiteContainerShareEvent from "@/components/Event/WhiteContainerShareEvent";
 import WhiteContainerSuggestJoinEvent from "@/components/Event/WhiteContainerSuggestJoinEvent";
+import WhiteContainerSuggestShareEvent from "@/components/Event/WhiteContainerSuggestShareEvent";
 import Footer from "@/components/Footer";
 import HeaderWithBackButton from "@/components/Header/HeaderWithBackButton";
 import WhiteContainer from "@/components/WhiteContainer";
@@ -158,7 +158,7 @@ const Event2024FallMissions = () => {
         <div css={{ height: "30px" }} />
         <CreditAmountStatusContainer />
         <WhiteContainerSuggestJoinEvent />
-        <WhiteContainerShareEvent />
+        <WhiteContainerSuggestShareEvent />
         {quests?.map((quest) => (
           <MissionContainer key={quest.id} quest={quest} />
         ))}
@@ -166,6 +166,6 @@ const Event2024FallMissions = () => {
       </AdaptiveDiv>
     </>
   );
-}; // ToDo : 2023fall 문구 및 footer
+};
 
 export default memo(Event2024FallMissions);

--- a/packages/web/src/pages/Event/Event2024FallMissions.tsx
+++ b/packages/web/src/pages/Event/Event2024FallMissions.tsx
@@ -14,7 +14,6 @@ import WhiteContainer from "@/components/WhiteContainer";
 
 import theme from "@/tools/theme";
 
-// ToDo : 2023fall 이미지
 import { ReactComponent as CreditIcon } from "@/static/events/2023fallCredit.svg";
 import { ReactComponent as MissionCompleteIcon } from "@/static/events/2023fallMissionComplete.svg";
 

--- a/packages/web/src/pages/Event/Event2024FallMissions.tsx
+++ b/packages/web/src/pages/Event/Event2024FallMissions.tsx
@@ -6,6 +6,7 @@ import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 
 import AdaptiveDiv from "@/components/AdaptiveDiv";
 import CreditAmountStatusContainer from "@/components/Event/CreditAmountStatusContainer";
+import WhiteContainerShareEvent from "@/components/Event/WhiteContainerShareEvent";
 import WhiteContainerSuggestJoinEvent from "@/components/Event/WhiteContainerSuggestJoinEvent";
 import Footer from "@/components/Footer";
 import HeaderWithBackButton from "@/components/Header/HeaderWithBackButton";
@@ -157,6 +158,7 @@ const Event2024FallMissions = () => {
         <div css={{ height: "30px" }} />
         <CreditAmountStatusContainer />
         <WhiteContainerSuggestJoinEvent />
+        <WhiteContainerShareEvent />
         {quests?.map((quest) => (
           <MissionContainer key={quest.id} quest={quest} />
         ))}

--- a/serve/invite-event.html
+++ b/serve/invite-event.html
@@ -38,10 +38,10 @@
     <meta property="og:title" content="Taxi 추석 이벤트 초대 링크" />
     <meta
       property="og:description"
-      content="링크로 이동하여 택시에 동승하세요!"
+      content="링크로 이동하여 Taxi 추석 이벤트에 참여하세요!"
     />
     <!-- TODO: FIXME -->
-    <meta property="og:image" content="%FRONT_URL%/graph.png" />
+    <meta property="og:image" content="%OG_URL%/eventInvite/%INVITER_ID%" />
     <meta property="og:locale" content="ko_KR" />
     <meta property="og:locale:alternate" content="en_US" />
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #824 

이벤트 

1. 이벤트 소개 페이지에 공유하기 섹션을 만들었습니다.
2. 이벤트 공유를 위한 모달을 이번 이벤트에 맞게 수정했습니다.
3. 이벤트 참여를 위한 모달을 해당 추천인 시스템에 맞게 수정하며, 문구도 함께 수정했습니다.
4. 퀘스트 페이지에서도 이벤트 공유를 할 수 있도록 카드를 추가했습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/60c0bcba-61fc-4749-b8a3-c6ca81825763)
![image](https://github.com/user-attachments/assets/683e6353-be96-4e04-9596-4a9c2a125c05)
![image](https://github.com/user-attachments/assets/7b516925-ba10-4da5-901e-d5d11b718829)
![image](https://github.com/user-attachments/assets/f02fd583-ecb2-44d3-add4-32e71eb5e5d9)
![image](https://github.com/user-attachments/assets/ebd72daa-5634-4054-bd3d-22d9b3466a2f)
![image](https://github.com/user-attachments/assets/977248d7-a765-4ef4-b44e-0b01652f6018)
![image](https://github.com/user-attachments/assets/e7f93f06-80fc-4c3e-ac3f-8b7bec4eda41)


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 카카오톡 공유 시, OG 이미지를 연결하면 좋을 것 같습니다.
