### PR TITLE
[Bug] 출석 체크 모달 스탬프가 찍히지 않음

### DIFF
--- a/packages/web/src/components/Event/DailyAttendanceCalendar/index.tsx
+++ b/packages/web/src/components/Event/DailyAttendanceCalendar/index.tsx
@@ -35,11 +35,15 @@ const getCalendarDates = () => {
     for (let i = 0; i < 7; i++) {
       let available = null;
       let checked = false;
+      const isEventDay =
+        date.isBefore(endDate) && date.isAfter(startDate, "day");
+
       if (date.isSame(today)) {
         available = "today";
+        if (isEventDay) checked = true; // FIXME: 이벤트 완료 API호출은 되지만 UI로는 스탬프가 안 찍히는 버그를 하드 픽스함
       } else if (date.isAfter(startDate) && date.isBefore(today)) {
         available = "past";
-      } else if (date.isBefore(endDate) && date.isAfter(startDate, "day")) {
+      } else if (isEventDay) {
         available = true;
       }
 

--- a/packages/web/src/components/Event/WhiteContainerSuggestShareEvent/index.tsx
+++ b/packages/web/src/components/Event/WhiteContainerSuggestShareEvent/index.tsx
@@ -10,6 +10,7 @@ import WhiteContainer from "@/components/WhiteContainer";
 import alertAtom from "@/atoms/alert";
 import { useSetRecoilState } from "recoil";
 
+import moment, { getToday } from "@/tools/moment";
 import theme from "@/tools/theme";
 
 const WhiteContainerSuggestShareEvent = () => {
@@ -20,6 +21,11 @@ const WhiteContainerSuggestShareEvent = () => {
   const [isOpenShare, setIsOpenShare] = useState<boolean>(false);
   const axios = useAxios();
   const setAlert = useSetRecoilState(alertAtom);
+
+  const today = getToday();
+  const startDate = moment("2024-09-06", "YYYY-MM-DD");
+  const endDate = moment("2024-09-24", "YYYY-MM-DD");
+  const isEventDay = today.isBefore(endDate) && today.isAfter(startDate, "day");
 
   const styleText = {
     ...theme.font14,
@@ -32,7 +38,7 @@ const WhiteContainerSuggestShareEvent = () => {
   };
 
   useEffect(() => {
-    if (isAgreeOnTermsOfEvent)
+    if (isAgreeOnTermsOfEvent && isEventDay)
       axios({
         url: `/events/2024fall/invites/create`,
         method: "post",
@@ -59,10 +65,13 @@ const WhiteContainerSuggestShareEvent = () => {
             css={styleButton}
             onClick={() => {
               if (inviteUrl) setIsOpenShare(true);
-              else
+              else if (isEventDay) {
                 setAlert(
                   "이벤트를 공유하기 위해서는 이벤트에 참여해야 합니다."
                 );
+              } else {
+                setAlert("이벤트 기간이 아닙니다.");
+              }
             }}
           >
             이벤트 공유하기

--- a/packages/web/src/components/ModalPopup/ModalEvent2024FallDailyAttendance.tsx
+++ b/packages/web/src/components/ModalPopup/ModalEvent2024FallDailyAttendance.tsx
@@ -37,6 +37,9 @@ const ModalEvent2024FallDailyAttendance = ({
   onChangeIsOpen,
 }: ModalEvent2024FallDailyAttendanceProps) => {
   const today = getToday();
+  // const today = moment("2024-09-23", "YYYY-MM-DD"); // FIXME: 배포 전에 수정
+  const endDate = moment("2024-09-24", "YYYY-MM-DD");
+  const isEventDay = today.isBefore(endDate);
 
   const [valueDate, setDate] = useState<Array<Nullable<number>>>([
     today.year(),
@@ -55,7 +58,8 @@ const ModalEvent2024FallDailyAttendance = ({
   );
 
   useEffect(() => {
-    const modalOpened = isAgreeOnTermsOfEvent && todayInitial.length === 0;
+    const modalOpened =
+      isEventDay && isAgreeOnTermsOfEvent && todayInitial.length === 0;
 
     if (onChangeIsOpen && modalOpened) {
       onChangeIsOpen(modalOpened); // 모달 열기 상태 변경

--- a/packages/web/src/components/ModalPopup/ModalEvent2024FallDailyAttendance.tsx
+++ b/packages/web/src/components/ModalPopup/ModalEvent2024FallDailyAttendance.tsx
@@ -89,7 +89,9 @@ const ModalEvent2024FallDailyAttendance = ({
           ...theme.font16_bold,
         }}
       >
-        오늘자 출석이 완료되었습니다.
+        {isEventDay
+          ? "오늘자 출석이 완료되었습니다. "
+          : "이벤트 기간이 아닙니다. "}
       </Button>
     </Modal>
   );

--- a/packages/web/src/pages/Event/Event2024Fall.tsx
+++ b/packages/web/src/pages/Event/Event2024Fall.tsx
@@ -14,6 +14,7 @@ import WhiteContainer from "@/components/WhiteContainer";
 import alertAtom from "@/atoms/alert";
 import { useSetRecoilState } from "recoil";
 
+import moment, { getToday } from "@/tools/moment";
 import theme from "@/tools/theme";
 
 import { ReactComponent as TaxiLogoIcon } from "@/static/assets/sparcsLogos/TaxiLogo.svg";
@@ -37,8 +38,13 @@ const Event2024Fall = () => {
     useValueRecoilState("event2024FallInfo") || {};
   const axios = useAxios();
 
+  const today = getToday();
+  const startDate = moment("2024-09-06", "YYYY-MM-DD");
+  const endDate = moment("2024-09-24", "YYYY-MM-DD");
+  const isEventDay = today.isBefore(endDate) && today.isAfter(startDate, "day");
+
   useEffect(() => {
-    if (isAgreeOnTermsOfEvent)
+    if (isAgreeOnTermsOfEvent && isEventDay)
       axios({
         url: `/events/2024fall/invites/create`,
         method: "post",
@@ -277,10 +283,13 @@ const Event2024Fall = () => {
               }}
               onClick={() => {
                 if (inviteUrl) setIsOpenShare(true);
-                else
+                else if (isEventDay) {
                   setAlert(
                     "이벤트를 공유하기 위해서는 이벤트에 참여해야 합니다."
                   );
+                } else {
+                  setAlert("이벤트 기간이 아닙니다. ");
+                }
               }}
             >
               이벤트 공유하기

--- a/packages/web/src/pages/Event/Event2024FallDailyAttendance.tsx
+++ b/packages/web/src/pages/Event/Event2024FallDailyAttendance.tsx
@@ -8,7 +8,7 @@ import Footer from "@/components/Footer";
 import HeaderWithLeftNav from "@/components/Header/HeaderWithLeftNav";
 import WhiteContainer from "@/components/WhiteContainer";
 
-import { getToday } from "@/tools/moment";
+import moment, { getToday } from "@/tools/moment";
 import theme from "@/tools/theme";
 
 import { ReactComponent as DailyAttendance } from "@/static/events/2024fallDailyAttendance.svg";
@@ -28,6 +28,8 @@ const DateSection = (props: DateSectionProps) => {
 
 const Event2024FallMissions = () => {
   const today = getToday();
+  const endDate = moment("2024-09-24", "YYYY-MM-DD");
+  const isEventDay = today.isBefore(endDate);
 
   const [valueDate, setDate] = useState<Array<Nullable<number>>>([
     today.year(),
@@ -65,7 +67,9 @@ const Event2024FallMissions = () => {
             ...theme.font16_bold,
           }}
         >
-          오늘자 출석이 완료되었습니다.
+          {isEventDay
+            ? "오늘자 출석이 완료되었습니다. "
+            : "이벤트 기간이 아닙니다. "}
         </Button>
 
         <Footer type="event-2024fall" />


### PR DESCRIPTION
modal when event is over

# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

- It closes #832 
- 이벤트가 끝나면 출석체크 모달이나 완료 API 호출 안 되게 버그 픽스함. 

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

![image](https://github.com/user-attachments/assets/d60234a1-0ca0-485f-8440-bc8d3eb55433)
-> 
![image](https://github.com/user-attachments/assets/63fc4b71-edc8-427d-940d-e26b093c4144)


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

