### PR TITLE
#838.2 2024 추석 이벤트: 결과 섹션 삭제

### DIFF
--- a/packages/web/src/pages/Home/EventSection/index.tsx
+++ b/packages/web/src/pages/Home/EventSection/index.tsx
@@ -1,7 +1,6 @@
 import EventSection2023Fall from "./EventSection2023Fall";
 import EventSection2023Spring from "./EventSection2023Spring";
 import EventSection2024Fall from "./EventSection2024Fall";
-import EventSection2024FallResult from "./EventSection2024FallResult";
 import EventSection2024Spring from "./EventSection2024Spring";
 
 import { eventMode } from "@/tools/loadenv";
@@ -17,7 +16,7 @@ const EventSection = () => {
     case "2024fall":
       return <EventSection2024Fall />;
     default:
-      return <EventSection2024FallResult />;
+      return null;
   }
 };
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #838

2024 추석 이벤트 결과 공지 섹션을 홈페이지에서 더이상 보여주지 않습니다.