### PR TITLE
#844 23:50~00:00 사이에 메인 페이지 접속 시 시간이 잘못 표시되는 이슈 해결

### DIFF
--- a/packages/web/src/pages/Home/SelectDate.tsx
+++ b/packages/web/src/pages/Home/SelectDate.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from "react";
 
 import Date from "./Date";
 
-import { getToday10 } from "@/tools/moment";
+import { getToday } from "@/tools/moment";
 import theme from "@/tools/theme";
 
 const getWeekDates = () => {
-  const today = getToday10();
+  const today = getToday();
   const date = today.clone().subtract(1, "day");
 
   return Array.apply(null, Array(8)).map((_, index) => {


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #844

SelectDate에서 날짜를 getToday10으로 불러오는데 여기에서 10분 단위로 올림되는 이슈가 있었던 것 같아요. getToday로 바꿔서 해결했습니다

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/a92b2dd7-e008-4249-b3dd-cec43418b53d)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->
