### PR TITLE
#869 [Refactor] Docker 이미지 사이즈 줄이기

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG back_url=https://taxi.sparcs.org/api
-ARG front_url=https://taxi.sparcs.org
-ARG og_url=https://og-image.taxi.sparcs.org
+ARG FRONT_URL=https://taxi.sparcs.org
+ARG BACK_URL=https://taxi.sparcs.org/api
+ARG OG_IMAGE_URL=https://og-image.taxi.sparcs.org
 
 FROM node:16.15.1-slim AS base
 
@@ -8,12 +8,12 @@ FROM base AS manager
 RUN npm install -g pnpm@latest-8 react-inject-env@2.1.0
 
 FROM manager AS builder
-ARG back_url
-ARG front_url
-ARG og_url
-ENV REACT_APP_BACK_URL=$back_url
-ENV REACT_APP_FRONT_URL=$front_url
-ENV REACT_APP_OG_URL=$og_url
+ARG FRONT_URL
+ARG BACK_URL
+ARG OG_IMAGE_URL
+ENV REACT_APP_FRONT_URL=$FRONT_URL
+ENV REACT_APP_BACK_URL=$BACK_URL
+ENV REACT_APP_OG_URL=$OG_IMAGE_URL
 WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm fetch
@@ -23,12 +23,12 @@ RUN pnpm --filter-prod @taxi/web... build
 RUN npx react-inject-env set
 
 FROM nginx:1.27.4 AS production
-ARG back_url
-ARG front_url
-ARG og_url
-ENV REACT_APP_BACK_URL=$back_url
-ENV REACT_APP_FRONT_URL=$front_url
-ENV REACT_APP_OG_URL=$og_url
+ARG FRONT_URL
+ARG BACK_URL
+ARG OG_IMAGE_URL
+ENV REACT_APP_FRONT_URL=$FRONT_URL
+ENV REACT_APP_BACK_URL=$BACK_URL
+ENV REACT_APP_OG_URL=$OG_IMAGE_URL
 COPY --from=builder /app/packages/web/build /app/build/
 COPY serve /app/serve/
 COPY serve/default.conf.template /etc/nginx/templates/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,37 @@
-FROM nginx:1.24.0
-WORKDIR /root
+ARG back_url=https://taxi.sparcs.org/api
+ARG front_url=https://taxi.sparcs.org
+ARG og_url=https://og-image.taxi.sparcs.org
 
-# Install curl & node & npm (from nvm)
-ENV NODE_VERSION v16.15.0
-RUN apt-get -qq update; \
-    apt-get -qq install curl; \
-    curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash; \
-    . /root/.nvm/nvm.sh; \
-    nvm install $NODE_VERSION; \
-    nvm alias default $NODE_VERSION; \
-    nvm use --delete-prefix default
-ENV PATH /root/.nvm/versions/node/$NODE_VERSION/bin:$PATH
+FROM node:16.15.1-slim AS base
 
-# Install base dependencies
-RUN npm install --global pnpm@8.6.6 serve@14.1.2 react-inject-env@2.1.0
+FROM base AS manager
+RUN npm install -g pnpm@latest-8 react-inject-env@2.1.0
 
-# Copy lockfile and prefetch depdendencies
-COPY pnpm-lock.yaml .
+FROM manager AS builder
+ARG back_url
+ARG front_url
+ARG og_url
+ENV REACT_APP_BACK_URL=$back_url
+ENV REACT_APP_FRONT_URL=$front_url
+ENV REACT_APP_OG_URL=$og_url
+WORKDIR /app
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm fetch
-
-# Copy repository
 COPY . .
+RUN pnpm --filter-prod @taxi/web... install --offline --frozen-lockfile
+RUN pnpm --filter-prod @taxi/web... build
+RUN npx react-inject-env set
 
-# Build
-RUN pnpm --filter @taxi/web... install --offline; \
-    pnpm --filter @taxi/web... build
+FROM nginx:1.27.4 AS production
+ARG back_url
+ARG front_url
+ARG og_url
+ENV REACT_APP_BACK_URL=$back_url
+ENV REACT_APP_FRONT_URL=$front_url
+ENV REACT_APP_OG_URL=$og_url
+COPY --from=builder /app/packages/web/build /app/build/
+COPY serve /app/serve/
+COPY serve/default.conf.template /etc/nginx/templates/
+RUN chmod +x /app
 
-# Move built files to root
-RUN mv /root/packages/web/build .
-RUN chmod 711 /root
-
-# Set default environment variables
-ENV REACT_APP_BACK_URL=https://taxi.sparcs.org/api \
-    REACT_APP_FRONT_URL=https://taxi.sparcs.org \
-    REACT_APP_OG_URL=https://og-image.taxi.sparcs.org
-
-# Serve with injected environment variables
 EXPOSE 80
-CMD ["sh", "-c", "envsubst '$$REACT_APP_FRONT_URL $$REACT_APP_OG_URL' < serve/default.conf > /etc/nginx/conf.d/default.conf && npx react-inject-env set && nginx -g 'daemon off;'"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm fetch
 COPY . .
-RUN pnpm --filter-prod @taxi/web... install --offline --frozen-lockfile
+RUN pnpm --filter-prod @taxi/web... install --offline
 RUN pnpm --filter-prod @taxi/web... build
 RUN npx react-inject-env set
 

--- a/serve/default.conf.template
+++ b/serve/default.conf.template
@@ -3,7 +3,7 @@ server {
     listen [::]:80;
 
     location ~ ^/invite/(?<room_id>[^/]+) {
-        root  /root/serve;
+        root  /app/serve;
         try_files /invite.html =404;
 
         sub_filter '%ROOM_ID%' $room_id;
@@ -13,7 +13,7 @@ server {
     }
 
     location ~ ^/event/2025spring-invite/(?<inviter_id>[^/]+) {
-        root  /root/serve;
+        root  /app/serve;
         try_files /invite-event.html =404;
 
         sub_filter '%INVITER_ID%' $inviter_id;
@@ -23,7 +23,7 @@ server {
     }
 
     location / {
-        root   /root/build;
+        root   /app/build;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
 


### PR DESCRIPTION
# Summary

It closes #869

- [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/) 이용해 사이즈를 2.99GB → 256MB로 줄였습니다. (약 91% 감소)
- ECR에 표시되는 기존 이미지의 사이즈는 1,136MB인데, 이는 압축된 크기입니다. ([Ref.](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-info.html))

  > Starting with Docker version 1.9, the Docker client compresses image layers before pushing them to a V2 Docker registry. The output of the **docker images** command shows the uncompressed image size. Therefore, keep in mind that Docker might return a larger image than the image shown in the AWS Management Console.

- 빌드 시간이 단축되었습니다.
  - AS-IS

      ```sh
      docker build --no-cache -t taxi-front:latest .  # 3m 31s (0/15 cache)
      docker build -t taxi-front:latest .             # 2m 29s (5/15 cache)
      ```

  - TO-BE

      ```sh
      docker build --no-cache -t taxi-front:latest .  # 2m 08s (2/20 cache)
      docker build -t taxi-front:latest .             # 1m 09s (8/20 cache)
      ```

- `pnpm build` 시 `tsc`와 `vite`가 사용되기 때문에 `pnpm fetch`, `pnpm install` 시 `--prod` flag를 사용하지 않았습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="540" alt="image" src="https://github.com/user-attachments/assets/01a4a060-2f5b-4150-9096-d96543490622" />
<img width="540" alt="image" src="https://github.com/user-attachments/assets/50ea51fb-2cab-43b2-a79b-def66d05bab0" />
<img width="540" alt="image" src="https://github.com/user-attachments/assets/0459a179-e567-4f83-9831-281bc5b813a2" />


# Further Work

- 디펜던시 설치 및 빌드 시 `--prod` flag를 사용하면 빌드 시간을 더욱 단축할 수 있습니다.
- GitHub Actions environment variables를 설정해 테스트 환경과 라이브 환경에서의 URL을 다르게 배포할 수 있습니다.