### PR TITLE
Respond feature for taxi chat

### DIFF
--- a/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/BodyText.tsx
@@ -9,17 +9,29 @@ import ButtonSend from "./ButtonSend";
 import regExpTest from "@/tools/regExpTest";
 import theme from "@/tools/theme";
 
+type ReplyTarget = {
+  chatId: string;
+  authorName: string;
+  content: string;
+} | null;
+
 type BodyTextProps = {
   sendMessage: ReturnType<typeof useSendMessage>;
+  replyTarget?: ReplyTarget;
+  onClearReplyTarget?: () => void;
 };
 
-const BodyText = ({ sendMessage }: BodyTextProps) => {
+const BodyText = ({ sendMessage, replyTarget, onClearReplyTarget }: BodyTextProps) => {
   const wrapRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>();
   const [height, setHeight] = useState<CSS["height"]>("32px");
   const [isSendingMessage, setIsSendingMessage] = useState<boolean>(false);
   const isEnterPressed = useRef<boolean>(false);
   const isShiftPressed = useRef<boolean>(false);
+  // textarea의 이벤트 핸들러는 sendMessage가 바뀔 때만 재바인딩되어 replyTarget을
+  // stale하게 캡처하므로, 전송 시점의 최신 값을 ref로 읽는다.
+  const replyTargetRef = useRef(replyTarget);
+  replyTargetRef.current = replyTarget;
 
   const [chatMsgLength, setChatMsgLength] = useState(0);
   const maxChatMsgLength = 140;
@@ -78,8 +90,17 @@ const BodyText = ({ sendMessage }: BodyTextProps) => {
 
     if (isMessageValid) {
       setIsSendingMessage(true);
-      const result = await sendMessage("text", { text: message });
+      const currentReplyTarget = replyTargetRef.current;
+      const isReply = !!currentReplyTarget;
+      const result = await sendMessage(
+        isReply ? "reply" : "text",
+        {
+          text: message,
+          ...(isReply ? { parentChatId: currentReplyTarget!.chatId } : {}),
+        }
+      );
       if (!result) textareaRef.current.value = message;
+      else if (isReply && onClearReplyTarget) onClearReplyTarget();
       setChatMsgLength(0);
       setIsSendingMessage(false);
     }
@@ -137,6 +158,11 @@ const BodyText = ({ sendMessage }: BodyTextProps) => {
     resizeEvent();
   };
   useEffect(refreshTextArea, [sendMessage]);
+
+  /* 답장 대상이 지정되면 바로 입력할 수 있도록 포커스 */
+  useEffect(() => {
+    if (replyTarget) textareaRef.current?.focus();
+  }, [replyTarget?.chatId]);
 
   return (
     <div

--- a/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/InputText/index.tsx
@@ -5,20 +5,36 @@ import BodyText from "./BodyText";
 
 import theme from "@/tools/theme";
 
+type ReplyTarget = {
+  chatId: string;
+  authorName: string;
+  content: string;
+} | null;
+
 type InputTextProps = {
   uploadedImage?: Nullable<File>;
   onChangeUploadedImage?: (file: Nullable<File>) => void;
   sendMessage: ReturnType<typeof useSendMessage>;
+  replyTarget?: ReplyTarget;
+  onClearReplyTarget?: () => void;
 };
 
 const InputText = ({
   uploadedImage,
   onChangeUploadedImage,
   sendMessage,
+  replyTarget,
+  onClearReplyTarget,
 }: InputTextProps) => {
   const inputMode = uploadedImage ? "image" : "text";
   const children = {
-    text: <BodyText sendMessage={sendMessage} />,
+    text: (
+      <BodyText
+        sendMessage={sendMessage}
+        replyTarget={replyTarget}
+        onClearReplyTarget={onClearReplyTarget}
+      />
+    ),
     image: (
       <BodyImage
         uploadedImage={uploadedImage as File}

--- a/packages/web/src/components/Chat/MessageForm/ReplyPreview.tsx
+++ b/packages/web/src/components/Chat/MessageForm/ReplyPreview.tsx
@@ -1,0 +1,67 @@
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import ReplyRoundedIcon from "@mui/icons-material/ReplyRounded";
+
+import theme from "@/tools/theme";
+
+type ReplyPreviewProps = {
+  authorName: string;
+  content: string;
+  onCancel: () => void;
+};
+
+const ReplyPreview = ({ authorName, content, onCancel }: ReplyPreviewProps) => (
+  <div
+    css={{
+      display: "flex",
+      alignItems: "center",
+      gap: "8px",
+      padding: "7px 10px",
+      background: theme.purple_light,
+      borderRadius: "12px",
+      boxShadow: theme.shadow_purple_input_inset,
+    }}
+  >
+    <ReplyRoundedIcon
+      style={{
+        fontSize: "16px",
+        fill: theme.purple,
+        transform: "scaleX(-1)",
+        flexShrink: 0,
+      }}
+    />
+    <div css={{ flex: 1, minWidth: 0 }}>
+      <div
+        css={{
+          ...theme.font10_bold,
+          color: theme.purple,
+        }}
+      >
+        {authorName}에게 답장
+      </div>
+      <div
+        css={{
+          ...theme.font12,
+          color: theme.gray_text,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {content}
+      </div>
+    </div>
+    <div
+      css={{
+        cursor: "pointer",
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+      }}
+      onClick={onCancel}
+    >
+      <CloseRoundedIcon style={{ fontSize: "18px", fill: theme.gray_text }} />
+    </div>
+  </div>
+);
+
+export default ReplyPreview;

--- a/packages/web/src/components/Chat/MessageForm/ToolSheet/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/ToolSheet/index.tsx
@@ -28,6 +28,13 @@ import { useSetRecoilState } from "recoil";
 import { dayNowClient, dayServerToClient } from "@/tools/day";
 import theme from "@/tools/theme";
 
+import { keyframes } from "@emotion/react";
+
+const slideUp = keyframes`
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
 type ToolSheetProps = {
   roomInfo: Nullable<Room>;
   isOpen: boolean;
@@ -105,23 +112,23 @@ const ToolSheet = ({
     setIsOpenSaveAccount(true);
   }, []);
 
-  const styleWrap = {
+  const stylePanel = {
     position: "absolute" as any,
     width: "100%",
     left: "0",
     bottom: "0",
-    transform: `translate(0, ${isOpen ? "0" : "calc(100% + 20px)"})`,
-    transition: "all 0.3s",
     padding: "16px 0 14px",
     background: theme.white,
     boxShadow: theme.shadow_clicked,
+    animation: `${slideUp} 0.25s ease`,
   };
   const style = {
     display: "flex",
     justifyContent: "space-around",
   };
   return (
-    <div css={styleWrap}>
+    <>
+      {/* 파일 input과 모달은 항상 마운트 유지 (모달은 전역 atom에 등록되므로 언마운트 시 닫힘) */}
       <input
         type="file"
         accept="image/jpg, image/png, image/jpeg, image/heic"
@@ -129,25 +136,30 @@ const ToolSheet = ({
         ref={inputImageRef}
         onChange={onChangeImage}
       />
-      <AdaptiveDiv type="center">
-        <div css={style}>
-          <ToolButton type="image" onClick={onClickImage} />
-          <ToolButton
-            type="settlement"
-            onClick={onClickSettlement}
-            isVaild={isDepart && !roomInfo?.settlementTotal}
-          />
-          <ToolButton
-            type="payment"
-            onClick={onClickPayment}
-            isVaild={
-              isDepart &&
-              !!roomInfo?.settlementTotal &&
-              settlementStatusForMe === "send-required"
-            }
-          />
+      {/* 3메뉴 패널은 + 버튼으로 열었을 때(isOpen)만 입력창 위에 출현 */}
+      {isOpen && (
+        <div css={stylePanel}>
+          <AdaptiveDiv type="center">
+            <div css={style}>
+              <ToolButton type="image" onClick={onClickImage} />
+              <ToolButton
+                type="settlement"
+                onClick={onClickSettlement}
+                isVaild={isDepart && !roomInfo?.settlementTotal}
+              />
+              <ToolButton
+                type="payment"
+                onClick={onClickPayment}
+                isVaild={
+                  isDepart &&
+                  !!roomInfo?.settlementTotal &&
+                  settlementStatusForMe === "send-required"
+                }
+              />
+            </div>
+          </AdaptiveDiv>
         </div>
-      </AdaptiveDiv>
+      )}
       {roomInfo && (
         <>
           <ModalChatSettlement
@@ -174,7 +186,7 @@ const ToolSheet = ({
           )}
         </>
       )}
-    </div>
+    </>
   );
 };
 

--- a/packages/web/src/components/Chat/MessageForm/index.tsx
+++ b/packages/web/src/components/Chat/MessageForm/index.tsx
@@ -8,6 +8,7 @@ import useSettlementFromChats from "@/hooks/chat/useSettlementFromChats";
 
 import InputText from "./InputText";
 import NewMessage from "./NewMessage";
+import ReplyPreview from "./ReplyPreview";
 import ToolSheet from "./ToolSheet";
 import ToolSheetOpenButton from "./ToolSheetOpenButton";
 import "./index.css";
@@ -18,6 +19,12 @@ import { useRecoilValue } from "recoil";
 import { scrollToBottom } from "@/tools/chat/scroll";
 import theme from "@/tools/theme";
 
+type ReplyTarget = {
+  chatId: string;
+  authorName: string;
+  content: string;
+} | null;
+
 type MessageFormProps = {
   layoutType: LayoutType;
   roomInfo: Nullable<Room>;
@@ -27,6 +34,8 @@ type MessageFormProps = {
   onChangeIsOpenToolSheet: (x: boolean) => void;
   messageBodyRef: RefObject<HTMLDivElement>;
   sendMessage: ReturnType<typeof useSendMessage>;
+  replyTarget?: ReplyTarget;
+  onClearReplyTarget?: () => void;
 };
 
 const MessageForm = ({
@@ -38,6 +47,8 @@ const MessageForm = ({
   onChangeIsOpenToolSheet,
   messageBodyRef,
   sendMessage,
+  replyTarget,
+  onClearReplyTarget,
 }: MessageFormProps) => {
   const isVKDetected = useRecoilValue(isVirtualKeyboardDetectedAtom);
   const [uploadedImage, setUploadedImage] = useState<Nullable<File>>(null); // 업로드된 이미지 파일
@@ -62,10 +73,15 @@ const MessageForm = ({
         : "env(safe-area-inset-bottom)"
     })`,
     display: "flex",
-    alignItems: "flex-end",
-    gap: "10px",
+    flexDirection: "column" as any,
+    gap: "8px",
     boxShadow: theme.shadow_clicked,
     background: theme.white,
+  };
+  const styleInputRow = {
+    display: "flex",
+    alignItems: "flex-end",
+    gap: "10px",
   };
 
   return (
@@ -86,24 +102,35 @@ const MessageForm = ({
         />
       </div>
       <div css={styleBody}>
-        <ToolSheetOpenButton
-          isOpen={isOpenToolSheet}
-          onChangeIsOpen={onChangeIsOpenToolSheet}
-        />
-        <div
-          css={{
-            flex: 1,
-            display: "flex",
-            flexDirection: "column",
-            gap: "7px",
-            minWidth: 0,
-          }}
-        >
-          <InputText
-            uploadedImage={uploadedImage}
-            onChangeUploadedImage={setUploadedImage}
-            sendMessage={sendMessage}
+        {replyTarget && onClearReplyTarget && (
+          <ReplyPreview
+            authorName={replyTarget.authorName}
+            content={replyTarget.content}
+            onCancel={onClearReplyTarget}
           />
+        )}
+        <div css={styleInputRow}>
+          <ToolSheetOpenButton
+            isOpen={isOpenToolSheet}
+            onChangeIsOpen={onChangeIsOpenToolSheet}
+          />
+          <div
+            css={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              gap: "7px",
+              minWidth: 0,
+            }}
+          >
+            <InputText
+              uploadedImage={uploadedImage}
+              onChangeUploadedImage={setUploadedImage}
+              sendMessage={sendMessage}
+              replyTarget={replyTarget}
+              onClearReplyTarget={onClearReplyTarget}
+            />
+          </div>
         </div>
       </div>
     </>

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/MessageReply.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/MessageReply.tsx
@@ -1,0 +1,85 @@
+import type { ParentChat } from "@/types/chat";
+
+import theme from "@/tools/theme";
+
+import ReplyRoundedIcon from "@mui/icons-material/ReplyRounded";
+
+type MessageReplyProps = {
+  text: string;
+  color: CSS["color"];
+  parentChat: ParentChat;
+  isSelf?: boolean;
+  onClickParent?: () => void;
+};
+
+const MessageReply = ({
+  text,
+  color,
+  parentChat,
+  isSelf,
+  onClickParent,
+}: MessageReplyProps) => {
+  const isLight = color === theme.white; // 내가 보낸 메시지(보라 버블)인지 여부
+
+  const accent = isLight ? "rgba(255,255,255,0.9)" : theme.purple;
+  const muted = isLight ? "rgba(255,255,255,0.65)" : theme.gray_text;
+  const divider = isLight ? "rgba(255,255,255,0.35)" : theme.gray_line;
+
+  return (
+    <div css={{ padding: "7px 10px 6px" }}>
+      <div
+        css={{
+          marginBottom: "6px",
+          cursor: onClickParent ? "pointer" : undefined,
+        }}
+        onClick={onClickParent}
+      >
+        <div
+          css={{
+            display: "flex",
+            alignItems: "center",
+            gap: "3px",
+            ...theme.font10_bold,
+            color: accent,
+            marginBottom: "2px",
+          }}
+        >
+          <ReplyRoundedIcon
+            style={{
+              fontSize: "12px",
+              fill: accent,
+              transform: "scaleX(-1)",
+              flexShrink: 0,
+            }}
+          />
+          {isSelf ? "나" : parentChat.nickname}에게 답장
+        </div>
+        <div
+          css={{
+            ...theme.font12,
+            color: muted,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {parentChat.content}
+        </div>
+      </div>
+      <div css={{ height: "1px", background: divider, marginBottom: "6px" }} />
+      <div
+        css={{
+          color,
+          wordBreak: "break-all",
+          ...theme.font14,
+          whiteSpace: "break-spaces",
+        }}
+        className="selectable"
+      >
+        {text}
+      </div>
+    </div>
+  );
+};
+
+export default MessageReply;

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.css
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.css
@@ -1,0 +1,28 @@
+/* 답장 원본으로 이동했을 때 원본 메시지를 살짝 hop(통통 튀는) 시키는 강조 애니메이션 */
+@keyframes chat-hop {
+  0% {
+    transform: translateY(0);
+  }
+  20% {
+    transform: translateY(-8px);
+  }
+  40% {
+    transform: translateY(0);
+  }
+  58% {
+    transform: translateY(-5px);
+  }
+  74% {
+    transform: translateY(0);
+  }
+  88% {
+    transform: translateY(-2px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+.chat-hop {
+  animation: chat-hop 0.6s ease;
+}

--- a/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/MessageSet/index.tsx
@@ -1,8 +1,9 @@
-import { memo, useCallback, useState } from "react";
+import { RefObject, memo, useCallback, useState } from "react";
 
 import type { BotChat, LayoutType, UserChat } from "@/types/chat";
 
 import useSettlementFromChats from "@/hooks/chat/useSettlementFromChats";
+import useSwipeToReply from "@/hooks/chat/useSwipeToReply";
 import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
 
 import { ModalChatReport } from "@/components/ModalPopup";
@@ -16,15 +17,20 @@ import MessageGameRecommendation from "./MessageGameRecommendation";
 import MessageImage from "./MessageImage";
 import MessagePaySettlement from "./MessagePaySettlement";
 import MessageRacing from "./MessageRacing";
+import MessageReply from "./MessageReply";
 import MessageShare from "./MessageShare";
 import MessageText from "./MessageText";
 import MessageWordChain from "./MessageWordChain";
+
+import ReplyRoundedIcon from "@mui/icons-material/ReplyRounded";
 
 import { getChatUniquewKey } from "@/tools/chat/chats";
 import dayjs from "@/tools/day";
 import theme from "@/tools/theme";
 
 import { ReactComponent as TaxiIcon } from "@/static/assets/sparcsLogos/TaxiAppIcon.svg";
+
+import "./index.css";
 
 type MessageBodyProps = {
   type: (UserChat | BotChat)["type"];
@@ -33,6 +39,9 @@ type MessageBodyProps = {
   color: CSS["color"];
   settlement: ReturnType<typeof useSettlementFromChats>;
   layoutType: LayoutType;
+  chat: UserChat | BotChat;
+  userOid?: string;
+  onClickParentChat?: () => void;
 };
 
 const MessageBody = ({
@@ -42,8 +51,28 @@ const MessageBody = ({
   color,
   settlement,
   layoutType,
+  chat,
+  userOid,
+  onClickParentChat,
 }: MessageBodyProps) => {
   switch (type) {
+    case "reply": {
+      const parentChat = ("parentChat" in chat && chat.parentChat) || {
+        originChatId: "",
+        authorId: "",
+        nickname: "알 수 없음",
+        content: "",
+      };
+      return (
+        <MessageReply
+          text={content}
+          color={color}
+          parentChat={parentChat}
+          isSelf={!!userOid && parentChat.authorId === userOid}
+          onClickParent={onClickParentChat}
+        />
+      );
+    }
     case "text":
       return <MessageText text={content} color={color} />;
     case "s3img":
@@ -93,11 +122,19 @@ const MessageBody = ({
   }
 };
 
+type ReplyTarget = {
+  chatId: string;
+  authorName: string;
+  content: string;
+};
+
 type MessageSetProps = {
   chats: Array<UserChat | BotChat>;
   layoutType: LayoutType;
   roomInfo: Room;
   readAtList: Array<Date>;
+  onSetReplyTarget?: (target: ReplyTarget) => void;
+  messageBodyRef?: RefObject<HTMLDivElement>;
 };
 
 const MessageSet = ({
@@ -105,12 +142,15 @@ const MessageSet = ({
   layoutType,
   roomInfo,
   readAtList,
+  onSetReplyTarget,
+  messageBodyRef,
 }: MessageSetProps) => {
   const [isOpenReport, setIsOpenReport] = useState<boolean>(false);
   const { oid: userOid } = useValueRecoilState("loginInfo") || {};
 
   const onClickProfileImage = useCallback(() => setIsOpenReport(true), []);
   const settlement = useSettlementFromChats(chats);
+  const makeSwipeHandlers = useSwipeToReply();
 
   const authorId = chats?.[0]?.authorId;
   const authorProfileUrl =
@@ -230,7 +270,7 @@ const MessageSet = ({
 
   return (
     <>
-      <div css={style}>
+      <div css={style} data-chat-row>
         <div css={styleProfileSection}>
           {authorId !== userOid && (
             <div
@@ -266,30 +306,161 @@ const MessageSet = ({
               </div>
             ))}
 
-          {chats.map((chat, index) => (
-            <div key={getChatUniquewKey(chat)} css={styleMessageWrap}>
-              <div css={styleChat(chat.type)}>
-                <MessageBody
-                  type={chat.type}
-                  content={chat.content}
-                  roomInfo={roomInfo}
-                  color={authorId === userOid ? theme.white : theme.black}
-                  settlement={settlement}
-                  layoutType={layoutType}
-                />
-              </div>
-              <div css={styleMessageDetail}>
-                {unreadUsersNum(chat.time) > 0 && (
-                  <div css={styleUnreadUsers}>{unreadUsersNum(chat.time)}</div>
-                )}
-                {index === chats.length - 1 && (
-                  <div css={styleTime} className="selectable">
-                    {dayjs(chat.time).format("H시 mm분")}
+          {chats.map((chat, index) => {
+            const handleReply = () => {
+              if (!onSetReplyTarget || isBot) return;
+              const name =
+                ("authorName" in chat && chat.authorName) || "알 수 없음";
+              onSetReplyTarget({
+                chatId: chat._id || "",
+                authorName: name,
+                content:
+                  chat.type === "s3img" ? "사진" : chat.content,
+              });
+            };
+
+            const handleClickParentChat = () => {
+              if (
+                !messageBodyRef?.current ||
+                chat.type !== "reply" ||
+                !("parentChat" in chat) ||
+                !chat.parentChat
+              )
+                return;
+              const targetEl = messageBodyRef.current.querySelector<HTMLElement>(
+                `[data-chat-id="${chat.parentChat.originChatId}"]`
+              );
+              if (targetEl) {
+                targetEl.scrollIntoView({ behavior: "smooth", block: "center" });
+                // 원본 메시지를 살짝 hop 시켜 강조 (스크롤이 자리잡은 뒤)
+                window.setTimeout(() => {
+                  targetEl.classList.remove("chat-hop");
+                  void targetEl.offsetWidth; // reflow로 재트리거 허용
+                  targetEl.classList.add("chat-hop");
+                  const handleEnd = () => {
+                    targetEl.classList.remove("chat-hop");
+                    targetEl.removeEventListener("animationend", handleEnd);
+                  };
+                  targetEl.addEventListener("animationend", handleEnd);
+                }, 260);
+              }
+            };
+
+            const isMyMessage = authorId === userOid;
+            const swipeHandlers = makeSwipeHandlers(
+              handleReply,
+              isMyMessage,
+              isBot || !onSetReplyTarget
+            );
+
+            return (
+              <div
+                key={getChatUniquewKey(chat)}
+                css={styleMessageWrap}
+                data-chat-item
+              >
+                {!isBot && onSetReplyTarget && (
+                  <div
+                    data-swipe-hint
+                    css={{
+                      position: "absolute",
+                      top: 0,
+                      bottom: 0,
+                      [isMyMessage ? "right" : "left"]: "6px",
+                      display: "flex",
+                      alignItems: "center",
+                      opacity: 0,
+                      transition: "opacity 0.15s",
+                      pointerEvents: "none",
+                    }}
+                  >
+                    <ReplyRoundedIcon
+                      style={{
+                        fontSize: "18px",
+                        fill: theme.purple,
+                        transform: "scaleX(-1)",
+                      }}
+                    />
                   </div>
                 )}
+                {authorId === userOid && !isBot && (
+                  <div
+                    css={{
+                      display: "flex",
+                      alignItems: "center",
+                      opacity: 0,
+                      transition: "opacity 0.15s",
+                      cursor: "pointer",
+                      "[data-chat-item]:hover &": { opacity: 1 },
+                      // 터치(폰)에선 호버 답장 버튼을 숨기고 스와이프로만 답장
+                      "@media (hover: none)": { display: "none" },
+                    }}
+                    onClick={handleReply}
+                  >
+                    <ReplyRoundedIcon
+                      style={{
+                        fontSize: "16px",
+                        fill: theme.gray_text,
+                        transform: "scaleX(-1)",
+                      }}
+                    />
+                  </div>
+                )}
+                <div
+                  css={styleChat(chat.type)}
+                  data-chat-id={chat._id}
+                  {...swipeHandlers}
+                >
+                  <MessageBody
+                    type={chat.type}
+                    content={chat.content}
+                    roomInfo={roomInfo}
+                    color={authorId === userOid ? theme.white : theme.black}
+                    settlement={settlement}
+                    layoutType={layoutType}
+                    chat={chat}
+                    userOid={userOid}
+                    onClickParentChat={handleClickParentChat}
+                  />
+                </div>
+                {authorId !== userOid && !isBot && (
+                  <div
+                    css={{
+                      display: "flex",
+                      alignItems: "center",
+                      opacity: 0,
+                      transition: "opacity 0.15s",
+                      cursor: "pointer",
+                      "[data-chat-item]:hover &": { opacity: 1 },
+                      // 터치(폰)에선 호버 답장 버튼을 숨기고 스와이프로만 답장
+                      "@media (hover: none)": { display: "none" },
+                    }}
+                    onClick={handleReply}
+                  >
+                    <ReplyRoundedIcon
+                      style={{
+                        fontSize: "16px",
+                        fill: theme.gray_text,
+                        transform: "scaleX(-1)",
+                      }}
+                    />
+                  </div>
+                )}
+                <div css={styleMessageDetail}>
+                  {unreadUsersNum(chat.time) > 0 && (
+                    <div css={styleUnreadUsers}>
+                      {unreadUsersNum(chat.time)}
+                    </div>
+                  )}
+                  {index === chats.length - 1 && (
+                    <div css={styleTime} className="selectable">
+                      {dayjs(chat.time).format("H시 mm분")}
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
       <ModalChatReport

--- a/packages/web/src/components/Chat/MessagesBody/index.tsx
+++ b/packages/web/src/components/Chat/MessagesBody/index.tsx
@@ -6,15 +6,22 @@ import useChatsForBody from "@/hooks/chat//useChatsForBody";
 
 import LoadingChats from "./LoadingChats";
 
+type ReplyTarget = {
+  chatId: string;
+  authorName: string;
+  content: string;
+};
+
 type MessagesBodyProps = {
   layoutType: LayoutType;
   roomInfo: Room;
   chats: Chats;
   readAtList: Array<Date>;
+  onSetReplyTarget?: (target: ReplyTarget) => void;
 };
 
 const MessagesBody = (
-  { layoutType, roomInfo, chats: _chats, readAtList }: MessagesBodyProps,
+  { layoutType, roomInfo, chats: _chats, readAtList, onSetReplyTarget }: MessagesBodyProps,
   ref: ForwardedRef<HTMLDivElement>
 ) => (
   <div
@@ -40,7 +47,9 @@ const MessagesBody = (
       ),
       layoutType,
       roomInfo,
-      readAtList
+      readAtList,
+      onSetReplyTarget,
+      typeof ref === "object" ? ref ?? undefined : undefined
     )}
   </div>
 );

--- a/packages/web/src/components/Chat/index.tsx
+++ b/packages/web/src/components/Chat/index.tsx
@@ -26,6 +26,11 @@ const Chat = ({ roomId, layoutType }: ChatProps) => {
   const [chats, setChats] = useStateWithCallbackLazy<Chats>([]); // 채팅 메시지 배열
   const [isDisplayNewMessage, setDisplayNewMessage] = useState<boolean>(false); // 새로운 메시지 버튼 표시 여부
   const [isOpenToolSheet, setIsOpenToolSheet] = useState<boolean>(false); // 툴 시트 표시 여부
+  const [replyTarget, setReplyTarget] = useState<{
+    chatId: string;
+    authorName: string;
+    content: string;
+  } | null>(null);
   const messageBodyRef = useRef<HTMLDivElement>(null); // 스크롤 되는 메시지 HTML 요소
   const isSendingMessage = useRef<boolean>(false); // 메시지 전송 중인지 여부
   const sendMessage = useSendMessage(roomId, isSendingMessage); // 메시지 전송 핸들러
@@ -93,6 +98,7 @@ const Chat = ({ roomId, layoutType }: ChatProps) => {
         roomInfo={roomInfo}
         chats={chats}
         readAtList={readAtList}
+        onSetReplyTarget={setReplyTarget}
         ref={messageBodyRef}
       />
       <MessageForm
@@ -104,6 +110,8 @@ const Chat = ({ roomId, layoutType }: ChatProps) => {
         onChangeIsOpenToolSheet={setIsOpenToolSheet}
         messageBodyRef={messageBodyRef}
         sendMessage={sendMessage}
+        replyTarget={replyTarget}
+        onClearReplyTarget={() => setReplyTarget(null)}
       />
       <ChatGameOverlay
         roomId={roomId}

--- a/packages/web/src/components/Skeleton/index.tsx
+++ b/packages/web/src/components/Skeleton/index.tsx
@@ -71,7 +71,8 @@ const Skeleton = ({ children }: SkeletonProps) => {
     useState<boolean>(false);
 
   useEvent2026SpringEffect();
-  useSyncRecoilStateEffect(); // loginIngo, taxiLocations, myRooms, notificationOptions 초기화 및 동기화
+  const isPublicPage = pathname.startsWith("/statistics");
+  useSyncRecoilStateEffect({ skipAuthFetches: isPublicPage });
   useI18nextEffect();
   useScrollRestorationEffect();
   useCSSVariablesEffect();

--- a/packages/web/src/hooks/chat/useChatsForBody.tsx
+++ b/packages/web/src/hooks/chat/useChatsForBody.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo } from "react";
+import { ReactNode, RefObject, useMemo } from "react";
 
 import type { BotChat, Chats, LayoutType, UserChat } from "@/types/chat";
 
@@ -14,11 +14,19 @@ import { getChatUniquewKey } from "@/tools/chat/chats";
 import dayjs from "@/tools/day";
 import moment from "@/tools/moment";
 
+type ReplyTarget = {
+  chatId: string;
+  authorName: string;
+  content: string;
+};
+
 export default (
   _chats: Chats,
   layoutType: LayoutType,
   roomInfo: Room,
-  readAtList: Date[]
+  readAtList: Date[],
+  onSetReplyTarget?: (target: ReplyTarget) => void,
+  messageBodyRef?: RefObject<HTMLDivElement>
 ) => {
   const { oid: userOid } = useValueRecoilState("loginInfo") || {};
 
@@ -38,6 +46,8 @@ export default (
             layoutType={layoutType}
             roomInfo={roomInfo}
             readAtList={readAtList}
+            onSetReplyTarget={onSetReplyTarget}
+            messageBodyRef={messageBodyRef}
           />
         );
       }
@@ -88,6 +98,7 @@ export default (
         item.type === "payment" ||
         item.type === "settlement" ||
         item.type === "account" ||
+        item.type === "reply" ||
         item.type === "share" ||
         item.type === "departure" ||
         item.type === "arrival" ||
@@ -135,5 +146,5 @@ export default (
     });
     popQueue();
     return list;
-  }, [_chats, layoutType, userOid, roomInfo, readAtList]);
+  }, [_chats, layoutType, userOid, roomInfo, readAtList, onSetReplyTarget, messageBodyRef]);
 };

--- a/packages/web/src/hooks/chat/useSendMessage.tsx
+++ b/packages/web/src/hooks/chat/useSendMessage.tsx
@@ -26,34 +26,40 @@ export default (
         | "image"
         | "wordChain"
         | "racing"
-        | "racingStart",
-      { text, file }: { text?: string; file?: File }
+        | "racingStart"
+        | "reply",
+      { text, file, parentChatId }: { text?: string; file?: File; parentChatId?: string }
     ): Promise<boolean> => {
       // 메시지 전송 중이라면 중복 전송을 막습니다.
       if (isSendingMessage.current) return false;
 
       try {
         if (
-          ["text", "account", "wordChain", "racing", "racingStart"].includes(
+          ["text", "account", "wordChain", "racing", "racingStart", "reply"].includes(
             type
           )
         ) {
           // 메시지가 정규식 검사에서 통과하지 못했다면 전송을 막습니다.
           if (!text) throw new Error();
           if (
-            ["text", "wordChain"].includes(type) &&
+            ["text", "wordChain", "reply"].includes(type) &&
             !regExpTest.chatMsg(text) &&
             !regExpTest.chatMsgLength(text)
           )
             throw new Error();
           if (type === "account" && !regExpTest.account(text))
             throw new Error();
+          if (type === "reply" && !parentChatId) throw new Error();
 
           isSendingMessage.current = true;
+          const data: Record<string, string> = { roomId, type, content: text };
+          if (type === "reply" && parentChatId) {
+            data.parentChat = parentChatId;
+          }
           const res = await axios({
             url: "/chats/send",
             method: "post",
-            data: { roomId, type, content: text },
+            data,
             onError: (e) => {
               throw e;
             },

--- a/packages/web/src/hooks/chat/useSwipeToReply.ts
+++ b/packages/web/src/hooks/chat/useSwipeToReply.ts
@@ -1,0 +1,92 @@
+import { TouchEvent, useCallback, useRef } from "react";
+
+const TRIGGER_PX = 52; // 답장이 트리거되는 드래그 거리
+const MAX_PX = 70; // 버블이 끌려가는 최대 거리
+const LOCK_PX = 6; // 가로/세로 방향 판정을 위한 최소 이동량
+
+type SwipeHandlers = {
+  onTouchStart?: (e: TouchEvent<HTMLDivElement>) => void;
+  onTouchMove?: (e: TouchEvent<HTMLDivElement>) => void;
+  onTouchEnd?: (e: TouchEvent<HTMLDivElement>) => void;
+};
+
+/**
+ * 채팅 버블을 가로로 끌어(스와이프) 답장을 트리거하는 터치 제스처 훅.
+ * 동시에 한 손가락 제스처만 일어나므로 컴포넌트 단위의 공유 ref로 상태를 관리한다.
+ * 반환된 factory를 chats.map 내부에서 호출해 버블별 핸들러를 만든다(훅 규칙 위배 없음).
+ */
+export default () => {
+  const active = useRef<boolean>(false);
+  const triggered = useRef<boolean>(false);
+  const startX = useRef<number>(0);
+  const startY = useRef<number>(0);
+  const axis = useRef<null | "h" | "v">(null);
+
+  const reset = (el: HTMLElement) => {
+    el.style.transition = "transform 0.2s ease";
+    el.style.transform = "";
+    const hint = el.parentElement?.querySelector<HTMLElement>(
+      "[data-swipe-hint]"
+    );
+    if (hint) hint.style.opacity = "0";
+  };
+
+  return useCallback(
+    (
+      onReply: () => void,
+      towardLeft: boolean,
+      disabled: boolean
+    ): SwipeHandlers => {
+      if (disabled) return {};
+      return {
+        onTouchStart: (e) => {
+          if (e.touches.length !== 1) return;
+          active.current = true;
+          triggered.current = false;
+          axis.current = null;
+          startX.current = e.touches[0].clientX;
+          startY.current = e.touches[0].clientY;
+        },
+        onTouchMove: (e) => {
+          if (!active.current) return;
+          const dx = e.touches[0].clientX - startX.current;
+          const dy = e.touches[0].clientY - startY.current;
+          if (axis.current === null) {
+            if (Math.abs(dx) < LOCK_PX && Math.abs(dy) < LOCK_PX) return;
+            axis.current = Math.abs(dx) > Math.abs(dy) ? "h" : "v";
+          }
+          if (axis.current === "v") return; // 세로 스크롤은 그대로 둔다
+          const el = e.currentTarget;
+          const dir = towardLeft ? -dx : dx; // 안쪽 방향이면 양수
+          if (dir <= 0) {
+            el.style.transform = "";
+            triggered.current = false;
+            const hint = el.parentElement?.querySelector<HTMLElement>(
+              "[data-swipe-hint]"
+            );
+            if (hint) hint.style.opacity = "0";
+            return;
+          }
+          const dist = Math.min(dir, MAX_PX);
+          el.style.transition = "none";
+          el.style.transform = `translateX(${towardLeft ? -dist : dist}px)`;
+          const hint = el.parentElement?.querySelector<HTMLElement>(
+            "[data-swipe-hint]"
+          );
+          if (hint) hint.style.opacity = String(Math.min(dist / TRIGGER_PX, 1));
+          const wasTriggered = triggered.current;
+          triggered.current = dist >= TRIGGER_PX;
+          if (triggered.current && !wasTriggered) navigator.vibrate?.(10);
+        },
+        onTouchEnd: (e) => {
+          if (!active.current) return;
+          active.current = false;
+          reset(e.currentTarget);
+          if (triggered.current) onReply();
+          triggered.current = false;
+        },
+      };
+    },
+    []
+  );
+};

--- a/packages/web/src/hooks/useFetchRecoilState/index.tsx
+++ b/packages/web/src/hooks/useFetchRecoilState/index.tsx
@@ -192,17 +192,24 @@ export const useFetchRecoilState = (atomName: AtomName) => {
   }
 };
 
-export const useSyncRecoilStateEffect = () => {
+export const useSyncRecoilStateEffect = (options?: {
+  skipAuthFetches?: boolean;
+}) => {
+  const { skipAuthFetches = false } = options || {};
   const loginInfo = useValueRecoilState("loginInfo");
   const { id: userId, deviceToken } = loginInfo || {};
 
   // userId 초기화 및 동기화
   const fetchLoginInfo = useFetchRecoilState("loginInfo");
-  useEffect(fetchLoginInfo, []);
+  useEffect(() => {
+    if (!skipAuthFetches) fetchLoginInfo();
+  }, [skipAuthFetches]);
 
   // taxiLocations 초기화 및 동기화
   const fetchTaxiLocations = useFetchRecoilState("taxiLocations");
-  useEffect(fetchTaxiLocations, []);
+  useEffect(() => {
+    if (!skipAuthFetches) fetchTaxiLocations();
+  }, [skipAuthFetches]);
 
   // myRooms 초기화 및 동기화
   const fetchMyRooms = useFetchRecoilState("myRooms");

--- a/packages/web/src/pages/Statistics/Statistics.tsx
+++ b/packages/web/src/pages/Statistics/Statistics.tsx
@@ -2,11 +2,15 @@ import _axios from "axios";
 import { useCallback, useEffect, useState } from "react";
 
 import { useValueRecoilState } from "@/hooks/useFetchRecoilState";
+import { useSetLoginInfo } from "@/hooks/useFetchRecoilState/useFetchLoginInfo";
+import { useSetTaxiLocations } from "@/hooks/useFetchRecoilState/useFetchTaxiLocations";
 import { useAxios } from "@/hooks/useTaxiAPI";
 import { backServer } from "@/tools/loadenv";
 
 // 로그인 없이도 호출 가능한 공용 통계 API용 (쿠키 미포함)
 const axiosAnon = _axios.create({ baseURL: backServer, withCredentials: false });
+// 리다이렉트 없이 로그인 상태를 확인하기 위한 인스턴스 (쿠키 포함)
+const axiosSilent = _axios.create({ baseURL: backServer, withCredentials: true });
 
 import AdaptiveDiv from "@/components/AdaptiveDiv";
 import Button from "@/components/Button";
@@ -44,6 +48,23 @@ const Statistics = () => {
   const axios = useAxios();
   const loginInfo = useValueRecoilState("loginInfo");
   const taxiLocations = useValueRecoilState("taxiLocations");
+  const setLoginInfo = useSetLoginInfo();
+  const setTaxiLocations = useSetTaxiLocations();
+
+  useEffect(() => {
+    if (!loginInfo) {
+      axiosSilent
+        .get("/logininfo")
+        .then((res) => setLoginInfo(res.data))
+        .catch(() => {});
+    }
+    if (!taxiLocations || taxiLocations.length === 0) {
+      axiosAnon
+        .get("/locations")
+        .then((res) => setTaxiLocations(res.data.locations))
+        .catch(() => {});
+    }
+  }, []);
 
   const [activeTab, setActiveTab] = useState<TabType>("all");
   const [period, setPeriod] = useState<Period>("30d");

--- a/packages/web/src/types/chat.d.ts
+++ b/packages/web/src/types/chat.d.ts
@@ -1,6 +1,7 @@
 export type LayoutType = "sidechat" | "fullchat" | "wordChainGame";
 
 type CommonChat = {
+  _id?: string; // 채팅의 objectId
   roomId: string; // 방의 objectId
   type: string;
   authorId?: string; // 작성자 objectId
@@ -9,13 +10,21 @@ type CommonChat = {
   isValid: boolean;
 };
 
+export type ParentChat = {
+  originChatId: string;
+  authorId: string;
+  nickname: string;
+  content: string;
+};
+
 export type UserChat = {
-  type: "text" | "s3img" | "payment" | "settlement" | "account";
+  type: "text" | "s3img" | "payment" | "settlement" | "account" | "reply";
   authorId: string;
   authorName: string;
   authorResidence?: string;
   authorProfileUrl: string;
   authorIsWithdrew: boolean;
+  parentChat?: ParentChat;
 } & CommonChat;
 export type GeneralChat = {
   type: "in" | "out";


### PR DESCRIPTION
# PR — 채팅 답장(Reply) 기능 + statistics 비로그인 접근 수정
---

## 1. Frontend PR

**branch:** `992-respond-feature-for-taxi-chat` → `dev`
**title:** `Add: chat reply feature`

### 개요
1. 원본 채팅을 인용해 답장하는 기능을 추가하고,
2. 함께 묶여 있던 statistics 공용 페이지의 비로그인 접근 버그를 수정합니다.


### 변경 사항

#### Add: chat 답장 기능
- **답장 모드 플로우**: 답장 버튼 또는 버블 스와이프 → 입력창 위 미리보기 표시 → (취소하지 않으면) **다음 1회 전송**이 `reply`로 나가고 자동 해제
- **답장 메시지 템플릿** (`MessageReply`): `↩ OOO에게 답장` 헤더 + 원본 1줄(말줄임) + 구분선 + 본문. 기존 디자인 토큰(보라/흰, font/​gray_line) 사용
  - 원본이 **본인 메시지**면 헤더를 **"나에게 답장"** 으로 표시
  - 사진(`s3img`) 원본은 인용에 "사진"으로 표시
- **원본으로 이동**: 인용 영역 탭 → 원본으로 스무스 스크롤 후 원본 버블이 살짝 **hop**(통통 튀는 강조) 애니메이션
- **모바일 스와이프-투-리플라이** (`useSwipeToReply`): 버블을 안쪽으로 가로 드래그 → 임계치 넘기면 ↩ 힌트 페이드인 + 햅틱 → 답장 진입. 세로 스크롤/단순 탭과 충돌 없음
- **호버 답장 버튼**: 데스크톱에선 **채팅별** 호버 시 표시, **터치(폰)에선 숨김**(스와이프 전용)
- **버그 수정**: 전송 핸들러의 stale closure(`replyTargetRef`)로 엔터 전송 시 `reply` 타입이 누락되던 문제 해결
- **레이아웃**: 답장 미리보기를 입력바 안으로 이동해 툴시트와 겹침 해결, 툴시트 3메뉴(사진/정산/송금)는 `+` 클릭 시에만 렌더

#### Fix: statistics 비로그인 접근
- 비로그인 상태로 `/statistics` 접근 시 auth fetch가 로그인 리다이렉트를 유발하던 문제 수정
- `useSyncRecoilStateEffect`에 `skipAuthFetches` 옵션 추가(Skeleton에서 `/statistics`일 때 활성화), 쿠키 미포함 공용 API로 위치 조회 + silent 인스턴스로 로그인 상태만 확인

### 주요 파일
| 파일 | 유형 |
|------|------|
| `hooks/chat/useSwipeToReply.ts` | 신규 |
| `components/Chat/MessagesBody/MessageSet/MessageReply.tsx` | 신규/재작성 |
| `components/Chat/MessageForm/ReplyPreview.tsx` | 신규 |
| `components/Chat/MessagesBody/MessageSet/index.css` | 신규 (hop 애니메이션) |
| `components/Chat/MessagesBody/MessageSet/index.tsx` | 수정 |
| `components/Chat/MessageForm/index.tsx` · `ToolSheet/index.tsx` · `InputText/{index,BodyText}.tsx` | 수정 |
| `components/Chat/{index,MessagesBody/index}.tsx` · `hooks/chat/{useSendMessage,useChatsForBody}.tsx` · `types/chat.d.ts` | 수정 |
| `pages/Statistics/Statistics.tsx` · `hooks/useFetchRecoilState/index.tsx` · `components/Skeleton/index.tsx` | 수정 (statistics) |

### 의존성
- `taxi-back` `698-reply-to-chat`의 채팅 응답에 `_id`·`parentChat` 포함 변경이 배포되어야 동작합니다.